### PR TITLE
Handle Shift-JIS file names in FNT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "ds-rom"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "bitfield-struct",
  "bitreader",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "ds-rom-cli"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "anyhow",
  "argp",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -231,6 +231,7 @@ dependencies = [
  "bitreader",
  "bytemuck",
  "crc",
+ "encoding_rs",
  "image",
  "log",
  "rust-bitwriter",
@@ -248,6 +249,15 @@ dependencies = [
  "ds-rom",
  "env_logger",
  "log",
+]
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ds-rom-cli"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Aetias <aetias@outlook.com>"]
 license = "MIT"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ds-rom"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 authors = ["Aetias <aetias@outlook.com>"]
 license = "MIT"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,6 +13,7 @@ bitfield-struct = "0.8.0"
 bitreader = "0.3.8"
 bytemuck = { version = "1.16.1", features = ["derive"] }
 crc = "3.2.1"
+encoding_rs = "0.8.34"
 image = { version = "0.25.1", default-features = false, features = ["png"] }
 log = "0.4.22"
 rust-bitwriter = "0.0.1"

--- a/lib/src/rom/file.rs
+++ b/lib/src/rom/file.rs
@@ -8,6 +8,7 @@ use std::{
     str::FromStr,
 };
 
+use encoding_rs::SHIFT_JIS;
 use snafu::{Backtrace, Snafu};
 
 use super::raw::{self, FileAlloc, Fnt, FntDirectory, FntFile, FntSubtable, RawHeaderError};
@@ -73,9 +74,9 @@ pub enum FileParseError {
 /// Errors related to [`FileSystem::build_fnt`].
 #[derive(Debug, Snafu)]
 pub enum FileBuildError {
-    /// Occurs when a file name contains non-ASCII characters.
-    #[snafu(display("the file name {name} contains one or more non-ASCII characters:\n{backtrace}"))]
-    NotAscii {
+    /// Occurs when a file name contains unmappable characters that could not be encoded to SHIFT-JIS.
+    #[snafu(display("the file name {name} contains unmappable character(s):\n{backtrace}"))]
+    EncodingFailed {
         /// File name.
         name: String,
         /// Backtrace to the source of the error.
@@ -247,15 +248,16 @@ impl<'a> FileSystem<'a> {
             let is_dir = Self::is_dir(child);
             let name = self.name(child);
 
-            let name_length = name.len() as u8 & 0x7f;
+            let (sjis_name, _, had_errors) = SHIFT_JIS.encode(name);
+            if had_errors {
+                return EncodingFailedSnafu { name }.fail();
+            }
+
+            let name_length = sjis_name.len() as u8 & 0x7f;
             let directory_bit = if is_dir { 0x80 } else { 0 };
             data.push(name_length | directory_bit);
-            for ch in name.chars().take(0x7f) {
-                if !ch.is_ascii() {
-                    return NotAsciiSnafu { name }.fail();
-                }
-                data.push(ch as u8);
-            }
+
+            data.extend(sjis_name.iter().take(0x7f));
             if is_dir {
                 data.write(&u16::to_le_bytes(child)).unwrap();
             }
@@ -296,14 +298,11 @@ impl<'a> FileSystem<'a> {
     fn compare_for_fnt(a: &str, a_dir: bool, b: &str, b_dir: bool) -> Ordering {
         let files_first = a_dir.cmp(&b_dir);
 
-        let len = a.len().min(b.len());
-        let a_chars = a[..len].chars().map(|c| c.to_ascii_lowercase());
-        let b_chars = b[..len].chars().map(|c| c.to_ascii_lowercase());
-        let alphabetic_order = a_chars.cmp(b_chars);
+        let a_chars = a.chars().map(|c| c.to_ascii_lowercase());
+        let b_chars = b.chars().map(|c| c.to_ascii_lowercase());
+        let lexicographic_alphabetic_order = a_chars.cmp(b_chars);
 
-        let shortest_first = a.len().cmp(&b.len());
-
-        files_first.then(alphabetic_order).then(shortest_first)
+        files_first.then(lexicographic_alphabetic_order)
     }
 
     fn sort_for_fnt_in(&mut self, parent_id: u16) {
@@ -327,14 +326,8 @@ impl<'a> FileSystem<'a> {
     }
 
     fn compare_for_rom(a: &str, b: &str) -> Ordering {
-        let len = a.len().min(b.len());
-        let a_chars = a[..len].chars();
-        let b_chars = b[..len].chars();
-        let ascii_order = a_chars.cmp(b_chars);
-
-        let shortest_first = a.len().cmp(&b.len());
-
-        ascii_order.then(shortest_first)
+        let lexicographic_order = a.cmp(b);
+        lexicographic_order
     }
 
     fn sort_for_rom_in(&mut self, parent_id: u16) {

--- a/lib/src/rom/file.rs
+++ b/lib/src/rom/file.rs
@@ -593,7 +593,7 @@ impl<'a> Display for DisplayFileSystem<'a> {
             } else {
                 let file = files.file(*child);
                 let size = BlobSize(file.contents.len()).to_string();
-                write!(f, "{i}0x{:04x}: {: <32}{size: >7}", file.id, file.name)?;
+                write!(f, "{i}0x{:04x}: {: <48}{size: >7}", file.id, file.name)?;
                 writeln!(f)?;
             }
         }

--- a/lib/src/rom/file.rs
+++ b/lib/src/rom/file.rs
@@ -297,12 +297,17 @@ impl<'a> FileSystem<'a> {
 
     fn compare_for_fnt(a: &str, a_dir: bool, b: &str, b_dir: bool) -> Ordering {
         let files_first = a_dir.cmp(&b_dir);
+        if files_first.is_ne() {
+            return files_first;
+        }
 
-        let a_chars = a.chars().map(|c| c.to_ascii_lowercase());
-        let b_chars = b.chars().map(|c| c.to_ascii_lowercase());
-        let lexicographic_alphabetic_order = a_chars.cmp(b_chars);
+        let a_lower = a.to_lowercase();
+        let b_lower = b.to_lowercase();
+        let (a_bytes, _, _) = SHIFT_JIS.encode(&a_lower);
+        let (b_bytes, _, _) = SHIFT_JIS.encode(&b_lower);
 
-        files_first.then(lexicographic_alphabetic_order)
+        // Lexicographic, case-insensitive Shift-JIS order
+        a_bytes.cmp(&b_bytes)
     }
 
     fn sort_for_fnt_in(&mut self, parent_id: u16) {
@@ -326,8 +331,8 @@ impl<'a> FileSystem<'a> {
     }
 
     fn compare_for_rom(a: &str, b: &str) -> Ordering {
-        let lexicographic_order = a.cmp(b);
-        lexicographic_order
+        // Lexicographic UTF-8 order
+        a.cmp(b)
     }
 
     fn sort_for_rom_in(&mut self, parent_id: u16) {

--- a/lib/src/rom/rom.rs
+++ b/lib/src/rom/rom.rs
@@ -412,8 +412,10 @@ impl<'a> Rom<'a> {
                 let mut plain_overlay = overlay.clone();
                 configs.push(OverlayConfig { info: plain_overlay.info().clone(), file_name: format!("{name}.bin") });
 
-                log::info!("Decompressing {processor} overlay {}/{}", overlay.id(), overlays.len() - 1);
-                plain_overlay.decompress();
+                if plain_overlay.is_compressed() {
+                    log::info!("Decompressing {processor} overlay {}/{}", overlay.id(), overlays.len() - 1);
+                    plain_overlay.decompress();
+                }
                 create_file(path.join(format!("{name}.bin")))?.write(plain_overlay.code())?;
             }
             serde_yml::to_writer(create_file(path.join("overlays.yaml"))?, &configs)?;


### PR DESCRIPTION
As found in #1, asset file names are encoded with Shift-JIS, while ds-rom treated them as UTF-8. I've now fixed this by adding the [`encoding_rs`](https://github.com/hsivonen/encoding_rs) crate which handles Shift-JIS encoding and decoding quite well.

The comparison functions for sorting files in the FNT and ROM have also been updated to handle Japanese file names correctly.