### PR TITLE
Improve compatibility for build info, DTCM and ROM padding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 /.vscode
 /*.bin
 /test
+/build.sh

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "ds-rom"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "bitfield-struct",
  "bitreader",
@@ -242,7 +242,7 @@ dependencies = [
 
 [[package]]
 name = "ds-rom-cli"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "anyhow",
  "argp",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ds-rom-cli"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Aetias <aetias@outlook.com>"]
 license = "MIT"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ds-rom"
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 authors = ["Aetias <aetias@outlook.com>"]
 license = "MIT"

--- a/lib/src/rom/header.rs
+++ b/lib/src/rom/header.rs
@@ -23,6 +23,10 @@ pub struct Header {
     /// Values for DS games after DSi release, [`HeaderVersion::DsPostDsi`].
     #[serde(skip_serializing_if = "Option::is_none")]
     pub ds_post_dsi: Option<HeaderDsPostDsi>,
+
+    /// Byte value to append between ROM sections. Note that this value is not actually from the header, but is still important
+    /// to define somewhere in order to obtain a matching ROM build.
+    pub padding_value: u8,
 }
 
 /// Values for the original header version, [`HeaderVersion::Original`].
@@ -82,9 +86,10 @@ pub enum HeaderBuildError {
 
 impl Header {
     /// Loads from a raw header.
-    pub fn load_raw(header: &raw::Header) -> Self {
+    pub fn load_raw(header: &raw::Header, padding_value: Option<u8>) -> Self {
         let version = header.version();
         Self {
+            padding_value: padding_value.unwrap_or(0xff),
             original: HeaderOriginal {
                 title: header.title.to_string(),
                 gamecode: header.gamecode,

--- a/lib/src/rom/raw/autoload_info.rs
+++ b/lib/src/rom/raw/autoload_info.rs
@@ -96,7 +96,7 @@ impl AutoloadInfo {
     pub fn kind(&self) -> AutoloadKind {
         match self.base_address {
             0x1ff8000 => AutoloadKind::Itcm,
-            0x27e0000 => AutoloadKind::Dtcm,
+            0x27e0000 | 0x27c0000 => AutoloadKind::Dtcm,
             _ => AutoloadKind::Unknown,
         }
     }

--- a/lib/src/rom/raw/rom.rs
+++ b/lib/src/rom/raw/rom.rs
@@ -243,6 +243,25 @@ impl<'a> Rom<'a> {
         Banner::borrow_from_slice(data)
     }
 
+    /// Returns the padding value between sections of this [`Rom`].
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::header`] and [`Self::banner`].
+    pub fn padding_value(&self) -> Result<u8, RawBannerError> {
+        let header = self.header()?;
+        let banner = self.banner()?;
+
+        // The banner has a known size which is never a multiple of 512,
+        // so it can't coincide with the start of another section.
+        //
+        // Therefore, we can use the first byte after the banner to determine
+        // the padding value.
+
+        let end = header.banner_offset as usize + banner.version().banner_size();
+        Ok(self.data[end])
+    }
+
     /// Returns a reference to the data of this [`Rom`].
     pub fn data(&self) -> &[u8] {
         &self.data

--- a/lib/src/rom/rom.rs
+++ b/lib/src/rom/rom.rs
@@ -9,8 +9,8 @@ use snafu::Snafu;
 
 use super::{
     raw::{
-        self, Arm9Footer, RawBannerError, RawBuildInfoError, RawFatError, RawFntError, RawHeaderError, RawOverlayError,
-        TableOffset,
+        self, Arm9Footer, RawArm9Error, RawBannerError, RawBuildInfoError, RawFatError, RawFntError, RawHeaderError,
+        RawOverlayError, TableOffset,
     },
     Arm7, Arm9, Arm9AutoloadError, Arm9Error, Arm9Offsets, Autoload, Banner, BannerError, BannerImageError, BuildInfo,
     FileBuildError, FileParseError, FileSystem, Header, HeaderBuildError, Logo, LogoError, LogoLoadError, LogoSaveError,
@@ -87,6 +87,12 @@ pub enum RomExtractError {
         /// Source error.
         source: FileParseError,
     },
+    /// See [`RawArm9Error`].
+    #[snafu(transparent)]
+    RawArm9 {
+        /// Source error.
+        source: RawArm9Error,
+    },
 }
 
 /// Errors related to [`Rom::build`].
@@ -162,7 +168,7 @@ pub enum RomSaveError {
     },
     /// See [`Arm9Error`].
     #[snafu(transparent)]
-    RawArm9 {
+    Arm9 {
         /// Source error.
         source: Arm9Error,
     },


### PR DESCRIPTION
As mentioned in #3, some games use the DTCM base address `027c0000` instead of the more common `027e0000`. This is fixed now, but I decided it was a good idea to look through other games I own to find other minor fixable issues.

I found that some ROMs don't provide a build info offset in the header, but do so in the ARM9 footer. This has been fixed by checking in both places.

Then there were a couple instances of games where the padding was `0x00` instead of the typical `0xff`. I decided to get this value by looking at the padding after the banner. There will always be padding there because the banner's size is never a multiple of 512 so it can't end precisely where a new section starts.

*(Maybe the padding is forced even if a section is exactly a multiple of 512 bytes long, but I have no example of this so I don't want take a risk here :p)*