### PR TITLE
Arbitrary autoloads and compression overhaul

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /*.bin
 /test
 /build.sh
+/build.ps1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,11 +227,13 @@ dependencies = [
 name = "ds-rom"
 version = "0.3.0"
 dependencies = [
+ "anyhow",
  "bitfield-struct",
  "bitreader",
  "bytemuck",
  "crc",
  "encoding_rs",
+ "env_logger",
  "image",
  "log",
  "rust-bitwriter",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "ds-rom"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "bitfield-struct",
@@ -244,7 +244,7 @@ dependencies = [
 
 [[package]]
 name = "ds-rom-cli"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "argp",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ds-rom-cli"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Aetias <aetias@outlook.com>"]
 license = "MIT"

--- a/cli/src/dump.rs
+++ b/cli/src/dump.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use anyhow::{bail, Result};
 use argp::FromArgs;
 use ds_rom::{
+    compress::lz77::Lz77,
     crypto::blowfish::BlowfishKey,
     rom::{self, raw, Logo, Overlay},
 };
@@ -60,6 +61,14 @@ pub struct Dump {
     /// Decompresses code modules.
     #[argp(switch, short = 'd')]
     decompress: bool,
+
+    /// Compare LZ77 compression algorithm output to the ROM. Use in combination with "print" switches.
+    #[argp(switch, short = 'L')]
+    compare_lz77: bool,
+
+    /// Shows the LZ77 tokens of a compressed module. Use in combination with "print" switches.
+    #[argp(switch, short = 'z')]
+    show_lz77_tokens: bool,
 
     /// Prints contents as raw bytes.
     #[argp(switch, short = 'R')]
@@ -132,7 +141,22 @@ impl Dump {
         }
 
         if self.print_arm9 {
-            print_hex(arm9.as_ref(), self.raw, arm9.base_address())?;
+            if self.compare_lz77 {
+                let mut recompressed = arm9.clone();
+                recompressed.decompress()?;
+                recompressed.compress()?;
+
+                Self::compare_lz77(arm9.full_data(), recompressed.full_data(), 0x4000, arm9.base_address() as usize);
+            }
+
+            if self.show_lz77_tokens {
+                let tokens = Lz77 {}.parse_tokens(arm9.full_data())?;
+                println!("{tokens}");
+            }
+
+            if !self.compare_lz77 && !self.show_lz77_tokens {
+                print_hex(arm9.as_ref(), self.raw, arm9.base_address())?;
+            }
         }
 
         if self.show_build_info {
@@ -178,7 +202,22 @@ impl Dump {
                 overlay.compress()?;
             }
 
-            print_hex(overlay.full_data(), self.raw, overlay.base_address())?;
+            if self.compare_lz77 {
+                let mut recompressed = overlay.clone();
+                recompressed.decompress();
+                recompressed.compress()?;
+
+                Self::compare_lz77(overlay.full_data(), recompressed.full_data(), 0, overlay.base_address() as usize);
+            }
+
+            if self.show_lz77_tokens {
+                let tokens = Lz77 {}.parse_tokens(overlay.full_data())?;
+                println!("{tokens}");
+            }
+
+            if !self.compare_lz77 && !self.show_lz77_tokens {
+                print_hex(overlay.full_data(), self.raw, overlay.base_address())?;
+            }
         }
 
         if self.print_arm7 {
@@ -210,5 +249,32 @@ impl Dump {
             println!("Files:\n{}", root.display(2));
         }
         Ok(())
+    }
+
+    fn compare_lz77(data_before: &[u8], data_after: &[u8], start: usize, base_address: usize) {
+        let before = data_before.len();
+        let after = data_after.len();
+
+        let mut equal = true;
+        if before != after {
+            println!("Wrong size: before = {before:#x}, after = {after:#x}");
+            equal = false;
+        }
+
+        let before = data_before.iter().enumerate().skip(start).rev();
+        let after = data_after.iter().enumerate().skip(start).rev();
+
+        for ((addr_before, value_before), (addr_after, value_after)) in before.zip(after) {
+            let addr_before = addr_before + base_address;
+            let addr_after = addr_after + base_address;
+            if value_before != value_after {
+                println!("{addr_before:08x}: {value_before:02x}  =>  {addr_after:08x}: {value_after:02x}");
+                equal = false;
+            }
+        }
+
+        if equal {
+            println!("Compression matched");
+        }
     }
 }

--- a/cli/src/dump.rs
+++ b/cli/src/dump.rs
@@ -196,7 +196,7 @@ impl Dump {
             let mut overlay = Overlay::parse(&arm9_ovt[index], fat, &rom)?;
 
             if self.decompress && overlay.is_compressed() {
-                overlay.decompress();
+                overlay.decompress()?;
             }
             if self.compress && !overlay.is_compressed() {
                 overlay.compress()?;
@@ -204,7 +204,7 @@ impl Dump {
 
             if self.compare_lz77 {
                 let mut recompressed = overlay.clone();
-                recompressed.decompress();
+                recompressed.decompress()?;
                 recompressed.compress()?;
 
                 Self::compare_lz77(overlay.full_data(), recompressed.full_data(), 0, overlay.base_address() as usize);

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ds-rom"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 authors = ["Aetias <aetias@outlook.com>"]
 license = "MIT"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -20,3 +20,7 @@ rust-bitwriter = "0.0.1"
 serde = { version = "1.0.204", features = ["derive"] }
 serde_yml = "0.0.10"
 snafu = { version = "0.8.3", features = ["backtrace"] }
+
+[dev-dependencies]
+anyhow = "1.0.86"
+env_logger = "0.11.5"

--- a/lib/src/compress/lz77.rs
+++ b/lib/src/compress/lz77.rs
@@ -32,6 +32,7 @@ pub struct Pair {
 }
 
 impl Pair {
+    /// Encodes this length-distance pair into two big-endian bytes.
     pub fn to_be_bytes(&self) -> [u8; 2] {
         let length = (self.length - MIN_SUBSEQUENCE) & LENGTH_MASK;
         let distance = (self.distance - MIN_SUBSEQUENCE) & DISTANCE_MASK;
@@ -39,6 +40,7 @@ impl Pair {
         value.to_be_bytes()
     }
 
+    /// Decodes two little-endian bytes into a length-distance pair.
     pub fn from_le_bytes(bytes: [u8; 2]) -> Self {
         let value = u16::from_le_bytes(bytes) as usize;
         let distance = (value & DISTANCE_MASK) + MIN_SUBSEQUENCE;
@@ -46,6 +48,7 @@ impl Pair {
         Self { length, distance }
     }
 
+    /// Decodes two big-endian bytes into a length-distance pair.
     pub fn from_be_bytes(bytes: [u8; 2]) -> Self {
         let value = u16::from_be_bytes(bytes) as usize;
         let distance = (value & DISTANCE_MASK) + MIN_SUBSEQUENCE;
@@ -53,8 +56,9 @@ impl Pair {
         Self { length, distance }
     }
 
+    /// Number of bytes saved by this length-distance pair.
     pub fn bytes_saved(&self) -> usize {
-        self.length - MIN_SUBSEQUENCE
+        self.length - 2
     }
 }
 
@@ -64,39 +68,7 @@ impl Display for Pair {
     }
 }
 
-#[derive(Clone, Copy, Debug)]
-struct BlockInfo {
-    pos: usize,
-    bytes_saved: isize,
-    flags: u8,
-    flag_count: u8,
-}
-
-impl Display for BlockInfo {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(
-            f,
-            "pos={:#x}, bytes_saved={}, flags=0x{:02x}, flag_count={}, read={}, written={}",
-            self.pos,
-            self.bytes_saved,
-            self.flags,
-            self.flag_count,
-            self.bytes_read(),
-            self.bytes_written()
-        )
-    }
-}
-
-impl BlockInfo {
-    fn bytes_written(&self) -> usize {
-        1 + self.flag_count as usize + self.flags.count_ones() as usize
-    }
-
-    fn bytes_read(&self) -> usize {
-        (self.bytes_written() as isize + self.bytes_saved) as usize
-    }
-}
-
+/// Errors related to [`Lz77::decompress`].
 #[derive(Debug, Snafu)]
 pub enum Lz77DecompressError {
     /// See [`Lz77ParseError`].
@@ -114,158 +86,6 @@ pub enum Lz77DecompressError {
 }
 
 impl Lz77 {
-    fn find_match(&self, bytes: &[u8], pos: usize) -> Option<Pair> {
-        let max_lookahead = (LOOKAHEAD + MAX_SUBSEQUENCE).min(bytes.len() - pos - 1);
-        (MIN_SUBSEQUENCE - 1..max_lookahead)
-            .fold(None, |best_pair, i| {
-                let needle = pos;
-                let haystack = pos + 1 + i;
-                if bytes[needle] != bytes[haystack] {
-                    return best_pair;
-                }
-                let mut length = 0;
-                while needle >= length
-                    && bytes[needle - length] == bytes[haystack - length]
-                    && haystack > pos + length
-                    && length < MAX_SUBSEQUENCE
-                {
-                    length += 1;
-                }
-                let distance = haystack - needle;
-                if length > best_pair.map_or(0, |p: Pair| p.length) && distance <= MAX_DISTANCE {
-                    Some(Pair { length, distance })
-                } else {
-                    best_pair
-                }
-            })
-            .and_then(|p| (p.length >= MIN_SUBSEQUENCE).then_some(p))
-    }
-
-    fn should_stop_ignoring_blocks(&self, version: HeaderVersion, saved: isize, next_block: Option<&&BlockInfo>) -> bool {
-        match version {
-            HeaderVersion::Original => saved < 0 && next_block.map_or(true, |b| b.bytes_saved >= 0),
-            HeaderVersion::DsPostDsi => saved <= 0,
-        }
-    }
-
-    fn compress_bytes(&self, version: HeaderVersion, bytes: &[u8], compressed: &mut Vec<u8>) -> Result<usize, io::Error> {
-        let mut block_infos = Vec::with_capacity(bytes.len() / 8);
-
-        let mut read = bytes.len();
-        let mut flags = 0;
-        let mut flag_count = 0;
-        let mut flag_pos = compressed.len();
-        compressed.push(0); // placeholder for flag byte
-        let mut bytes_saved = 0; // current block only
-        while read > 0 {
-            flags <<= 1;
-            if let Some(pair) = self.find_match(bytes, read - 1) {
-                // write length-distance pair
-                read -= pair.length;
-                let encoded = pair.to_be_bytes();
-                compressed.write(&encoded)?;
-                flags |= 1;
-                let saved = (pair.length - encoded.len()) as isize;
-                bytes_saved += saved;
-            } else {
-                // write literal
-                read -= 1;
-                compressed.write(&[bytes[read]])?;
-            }
-
-            flag_count += 1;
-            if flag_count == 8 {
-                // write flag byte
-                compressed[flag_pos] = flags;
-                bytes_saved -= 1;
-                flag_pos = compressed.len();
-                block_infos.push(BlockInfo { pos: compressed.len(), bytes_saved, flags, flag_count });
-                bytes_saved = 0;
-                compressed.push(0); // placeholder for flag byte
-                flags = 0;
-                flag_count = 0;
-            }
-        }
-
-        if flag_count != 0 {
-            // trailing flag byte
-            flags <<= 8 - flag_count;
-            bytes_saved -= 1;
-            block_infos.push(BlockInfo { pos: compressed.len(), bytes_saved, flags, flag_count });
-            bytes_saved = 0;
-            compressed[flag_pos] = flags;
-        } else {
-            compressed.pop(); // remove unused flag byte placeholder
-        }
-
-        let mut num_identical: usize = 0;
-
-        // Save more bytes by ignoring blocks that have no length-distance pairs in them
-        let mut iter = block_infos.iter().rev().peekable();
-        let mut block_bytes_saved = 0;
-        let mut block_bytes_read = 0;
-        let mut last_block = None;
-        while let Some(block) = iter.next() {
-            block_bytes_saved += block.bytes_saved;
-            if block.bytes_saved != 0 {
-                if self.should_stop_ignoring_blocks(version, bytes_saved - block_bytes_saved, iter.peek()) {
-                    if bytes_saved > 0 {
-                        num_identical += block_bytes_read + block.flags.trailing_zeros() as usize;
-                    }
-                    last_block = Some(block);
-                    break;
-                }
-                num_identical += block_bytes_read;
-                bytes_saved -= block_bytes_saved;
-
-                // reset
-                block_bytes_saved = 0;
-                block_bytes_read = 0;
-            }
-            block_bytes_read += block.bytes_read();
-        }
-
-        // Remove leftover length-distance pairs depending on bytes saved
-        if bytes_saved > 1 {
-            if let Some(block) = last_block {
-                flags = block.flags;
-                read = block.pos - 1;
-
-                for _ in 0..8 {
-                    read -= 1;
-                    if flags & 0x01 != 0 {
-                        if bytes_saved <= 1 {
-                            break;
-                        }
-                        let pair = Pair::from_le_bytes([compressed[read + 1], compressed[read]]);
-                        let pair_bytes_saved = pair.length as isize - 2;
-                        if bytes_saved >= pair_bytes_saved {
-                            bytes_saved -= pair_bytes_saved;
-                            num_identical += pair.length;
-                        } else {
-                            break;
-                        }
-                        read -= 1;
-                    } else {
-                        num_identical += 1;
-                    }
-                    flags >>= 1;
-                }
-            }
-        }
-
-        // Remove remaining bytes saved from the compressed file
-        // `bytes_saved` is always positive or zero here
-        compressed.resize((compressed.len() as isize - bytes_saved) as usize, 0);
-
-        let write = compressed.len() - 1;
-        for i in 0..num_identical {
-            compressed[write - i] = bytes[i];
-        }
-
-        Ok(num_identical)
-    }
-
     fn compress_bytes2(&self, version: HeaderVersion, bytes: &[u8], compressed: &mut Vec<u8>) -> Result<usize, io::Error> {
         let mut tokens = Tokens::compress(bytes);
         tokens.drop_wasteful_tokens()?;
@@ -312,35 +132,6 @@ impl Lz77 {
         self.write_footer(&mut compressed, bytes, start, num_identical)?;
 
         Ok(compressed.into_boxed_slice())
-    }
-
-    fn decompress_bytes(&self, bytes: &[u8], decompressed: &mut Vec<u8>) {
-        let mut read: isize = bytes.len() as isize - 1;
-
-        while read > 0 {
-            let mut flags = bytes[read as usize];
-            read -= 1;
-            for _ in 0..8 {
-                if (flags & 0x80) == 0 {
-                    // read literal
-                    decompressed.push(bytes[read as usize]);
-                    read -= 1;
-                } else {
-                    // read length-distance pair
-                    let encoded = [bytes[read as usize - 1], bytes[read as usize]];
-                    read -= 2;
-                    let pair = Pair::from_le_bytes(encoded);
-                    let pos = decompressed.len();
-                    for i in 0..pair.length {
-                        decompressed.push(decompressed[pos - pair.distance + i]);
-                    }
-                }
-                if read < 0 {
-                    break;
-                }
-                flags <<= 1;
-            }
-        }
     }
 
     fn read_footer(&self, bytes: &[u8]) -> (usize, usize, usize) {
@@ -395,7 +186,7 @@ impl<'a> Token<'a> {
     fn bytes_saved(&self) -> isize {
         match self {
             Token::Literal(_) => 0,
-            Token::Pair((pair, _)) => pair.length as isize - 2,
+            Token::Pair((pair, _)) => pair.bytes_saved() as isize,
         }
     }
 }
@@ -409,11 +200,14 @@ impl<'a> Display for Token<'a> {
     }
 }
 
+/// Represents LZ77 tokens of a compressed stream.
 pub struct Tokens<'a> {
     tokens: Vec<Token<'a>>,
-    extra_bytes: Vec<u8>,
+    bytes_saved: isize,
+    dropped_tokens: usize,
 }
 
+/// Errors related to [`Tokens::decompress`].
 #[derive(Debug, Snafu)]
 pub enum Lz77ParseError {
     /// Occurs when a byte literal is expected directly after a flag byte, but there are no more bytes to read.
@@ -490,9 +284,14 @@ impl<'a> Tokens<'a> {
         let mut tokens = vec![];
 
         let mut read = bytes.len();
+        let mut bytes_saved = 0;
         while read > 0 {
+            if (tokens.len() % 8) == 0 {
+                bytes_saved -= 1;
+            }
             if let Some(pair) = Self::find_match(bytes, read - 1) {
                 read -= pair.length;
+                bytes_saved += pair.bytes_saved() as isize;
                 tokens.push(Token::Pair((pair, Cow::Borrowed(&bytes[read..read + pair.length]))));
             } else {
                 read -= 1;
@@ -500,45 +299,54 @@ impl<'a> Tokens<'a> {
             }
         }
 
-        return Self { tokens, extra_bytes: vec![].into() };
+        return Self { tokens, bytes_saved, dropped_tokens: 0 };
     }
 
     fn drop_wasteful_tokens(&mut self) -> Result<(), io::Error> {
-        let mut tokens_to_drop = 0;
-        let mut flag_bytes_saved: isize = 0;
-        for (index, token) in self.tokens.iter().enumerate().rev() {
-            let Token::Pair((pair, _)) = token else { continue };
-            flag_bytes_saved -= pair.bytes_saved() as isize;
-            if (index % 8) == 7 {
-                flag_bytes_saved += 1;
-            }
-            if flag_bytes_saved >= 0 {
-                tokens_to_drop = (self.tokens.len() - 1) - index;
+        let mut best_token_index = None;
+
+        let mut bytes_saved = 0;
+        'outer: for (i, chunk) in self.tokens.chunks(8).enumerate() {
+            for (j, token) in chunk.iter().enumerate() {
+                let index = i * 8 + j;
+                if (index % 8) == 0 {
+                    bytes_saved -= 1;
+                }
+                bytes_saved += token.bytes_saved();
+
+                if bytes_saved > self.bytes_saved {
+                    best_token_index = Some(index);
+                    break 'outer;
+                }
             }
         }
 
-        for _ in 0..tokens_to_drop {
-            let last_token = self.tokens.last().unwrap().clone();
-            match last_token {
-                Token::Literal(byte) => {
-                    self.extra_bytes.push(byte);
-                }
-                Token::Pair((_, bytes)) => {
-                    self.extra_bytes.write(&bytes)?;
-                }
-            }
-            self.tokens.pop();
-        }
+        let Some(best_token_index) = best_token_index else { return Ok(()) };
+        self.dropped_tokens = self.tokens.len() - best_token_index - 1;
 
         Ok(())
     }
 
-    fn write(mut self, compressed: &mut Vec<u8>) -> Result<usize, io::Error> {
-        for chunk in self.tokens.chunks(8) {
-            let flags = chunk.iter().fold(0u8, |acc, token| (acc << 1) | matches!(token, Token::Pair(_)) as u8)
-                << (8 - chunk.len() as u8);
+    fn make_flags_for_chunk(chunk: &[Token]) -> u8 {
+        chunk.iter().fold(0u8, |acc, token| (acc << 1) | matches!(token, Token::Pair(_)) as u8) << (8 - chunk.len() as u8)
+    }
+
+    fn write(self, compressed: &mut Vec<u8>) -> Result<usize, io::Error> {
+        let last_token_index = self.tokens.len() - self.dropped_tokens;
+        'outer: for (i, chunk) in self.tokens.chunks(8).enumerate() {
+            let flags = Self::make_flags_for_chunk(chunk);
+            let index = i * 8;
+            if index >= last_token_index {
+                break 'outer;
+            }
+
             compressed.push(flags);
-            for token in chunk {
+            for (j, token) in chunk.iter().enumerate() {
+                let index = index + j;
+                if index >= last_token_index {
+                    break 'outer;
+                }
+
                 match token {
                     Token::Literal(byte) => compressed.push(*byte),
                     Token::Pair((pair, _)) => {
@@ -548,17 +356,32 @@ impl<'a> Tokens<'a> {
             }
         }
 
-        self.extra_bytes.reverse();
-        compressed.write(&self.extra_bytes)?;
+        let mut num_identical = 0;
+        for token in &self.tokens[last_token_index..] {
+            match token {
+                Token::Literal(byte) => {
+                    num_identical += 1;
+                    compressed.push(*byte);
+                }
+                Token::Pair((_, bytes)) => {
+                    num_identical += bytes.len();
+                    for &byte in bytes.iter().rev() {
+                        compressed.push(byte);
+                    }
+                }
+            }
+        }
 
-        Ok(self.extra_bytes.len())
+        Ok(num_identical)
     }
 
     fn decompress(bytes: &'a [u8], start: usize, decompressed: &mut Vec<u8>) -> Result<Self, Lz77ParseError> {
         let mut tokens = vec![];
         let mut iter = bytes.iter().cloned().enumerate().skip(start).rev().peekable();
+        let mut bytes_saved = 0;
 
         while let Some((offset, mut flags)) = iter.next() {
+            bytes_saved -= 1;
             for _ in 0..8 {
                 if (flags & 0x80) == 0 {
                     let literal = iter.next().ok_or_else(|| NoLiteralSnafu { offset, flags }.build())?.1;
@@ -568,6 +391,8 @@ impl<'a> Tokens<'a> {
                     let (offset, first) = iter.next().ok_or_else(|| NoPairSnafu { offset, flags }.build())?;
                     let pair = [first, iter.next().ok_or_else(|| IncompletePairSnafu { offset }.build())?.1];
                     let pair = Pair::from_be_bytes(pair);
+
+                    bytes_saved += pair.bytes_saved() as isize;
 
                     if pair.distance > decompressed.len() {
                         OutOfBoundsSnafu { pair, offset }.fail()?;
@@ -591,21 +416,23 @@ impl<'a> Tokens<'a> {
             }
         }
 
-        Ok(Self { tokens, extra_bytes: vec![] })
+        Ok(Self { tokens, bytes_saved, dropped_tokens: 0 })
     }
 }
 
 impl<'a> Display for Tokens<'a> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let mut bytes_saved: isize = 0;
-        for chunk in self.tokens.rchunks(8).rev() {
+        for chunk in self.tokens.chunks(8) {
+            let flags = Self::make_flags_for_chunk(chunk);
+            bytes_saved -= 1;
+            writeln!(f, "saved: {bytes_saved} | {flags:02x} (flags)")?;
             for token in chunk {
                 bytes_saved += token.bytes_saved();
                 writeln!(f, "saved: {bytes_saved} | {token}")?;
             }
-            bytes_saved -= 1;
         }
-        writeln!(f, "Extra: {:x?}", self.extra_bytes)?;
+        writeln!(f, "Bytes saved: {}", self.bytes_saved)?;
         Ok(())
     }
 }

--- a/lib/src/rom/arm9.rs
+++ b/lib/src/rom/arm9.rs
@@ -8,7 +8,7 @@ use super::{
     Autoload,
 };
 use crate::{
-    compress::lz77::Lz77,
+    compress::lz77::{Lz77, Lz77DecompressError},
     crc::CRC_16_MODBUS,
     crypto::blowfish::{Blowfish, BlowfishError, BlowfishKey, BlowfishLevel},
 };
@@ -73,6 +73,12 @@ pub enum Arm9Error {
     RawBuildInfo {
         /// Source error.
         source: RawBuildInfoError,
+    },
+    /// See [`Lz77DecompressError`].
+    #[snafu(transparent)]
+    Lz77Decompress {
+        /// Source error.
+        source: Lz77DecompressError,
     },
     /// See [`io::Error`].
     #[snafu(transparent)]
@@ -330,7 +336,7 @@ impl<'a> Arm9<'a> {
             return Ok(());
         }
 
-        let data: Cow<[u8]> = LZ77.decompress(&self.data).into_vec().into();
+        let data: Cow<[u8]> = LZ77.decompress(&self.data)?.into_vec().into();
         let old_data = replace(&mut self.data, data);
         let build_info = match self.build_info_mut() {
             Ok(build_info) => build_info,

--- a/lib/src/rom/config.rs
+++ b/lib/src/rom/config.rs
@@ -28,7 +28,7 @@ pub struct RomConfig {
     /// Path to DTCM files
     pub dtcm: RomConfigAutoload,
     /// Path to unknown autoloads
-    #[serde(skip_serializing_if = "Vec::is_empty")]
+    #[serde(skip_serializing_if = "Vec::is_empty", default = "Vec::new")]
     pub unknown_autoloads: Vec<RomConfigAutoload>,
 
     /// Path to ARM9 overlays YAML

--- a/lib/src/rom/config.rs
+++ b/lib/src/rom/config.rs
@@ -23,14 +23,13 @@ pub struct RomConfig {
     /// Path to ARM7 YAML
     pub arm7_config: PathBuf,
 
-    /// Path to ITCM binary
-    pub itcm_bin: PathBuf,
-    /// Path to ITCM YAML
-    pub itcm_config: PathBuf,
-    /// Path to DTCM binary
-    pub dtcm_bin: PathBuf,
-    /// Path to DTCM YAML
-    pub dtcm_config: PathBuf,
+    /// Path to ITCM files
+    pub itcm: RomConfigAutoload,
+    /// Path to DTCM files
+    pub dtcm: RomConfigAutoload,
+    /// Path to unknown autoloads
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub unknown_autoloads: Vec<RomConfigAutoload>,
 
     /// Path to ARM9 overlays YAML
     pub arm9_overlays: Option<PathBuf>,
@@ -44,4 +43,13 @@ pub struct RomConfig {
     pub files_dir: PathBuf,
     /// Path to path order file
     pub path_order: PathBuf,
+}
+
+/// Path to autoload files
+#[derive(Serialize, Deserialize, Clone)]
+pub struct RomConfigAutoload {
+    /// Path to binary
+    pub bin: PathBuf,
+    /// Path to YAML
+    pub config: PathBuf,
 }

--- a/lib/src/rom/overlay.rs
+++ b/lib/src/rom/overlay.rs
@@ -3,7 +3,7 @@ use std::{borrow::Cow, io};
 use serde::{Deserialize, Serialize};
 
 use super::raw::{self, FileAlloc, HeaderVersion, OverlayCompressedSize, RawHeaderError};
-use crate::compress::lz77::Lz77;
+use crate::compress::lz77::{Lz77, Lz77DecompressError};
 
 /// An overlay module for ARM9/ARM7.
 #[derive(Clone)]
@@ -104,12 +104,13 @@ impl<'a> Overlay<'a> {
     }
 
     /// Decompresses this [`Overlay`], but does nothing if already decompressed.
-    pub fn decompress(&mut self) {
+    pub fn decompress(&mut self) -> Result<(), Lz77DecompressError> {
         if !self.is_compressed() {
-            return;
+            return Ok(());
         }
-        self.data = LZ77.decompress(&self.data).into_vec().into();
+        self.data = LZ77.decompress(&self.data)?.into_vec().into();
         self.info.compressed = false;
+        Ok(())
     }
 
     /// Compresses this [`Overlay`], but does nothing if already compressed.

--- a/lib/src/rom/raw/autoload_info.rs
+++ b/lib/src/rom/raw/autoload_info.rs
@@ -11,7 +11,7 @@ use super::RawBuildInfoError;
 
 /// Info about an autoload block.
 #[repr(C)]
-#[derive(Clone, Copy, Zeroable, Pod, Deserialize, Serialize)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug, Zeroable, Pod, Deserialize, Serialize)]
 pub struct AutoloadInfo {
     /// Base address of the autoload module.
     pub base_address: u32,
@@ -28,8 +28,8 @@ pub enum AutoloadKind {
     Itcm,
     /// Data TCM (Tightly Coupled Memory). Mainly used to make data have fast and predictable access times.
     Dtcm,
-    /// Unknown autoload kind.
-    Unknown,
+    /// Other autoload block of unknown purpose.
+    Unknown(AutoloadInfo),
 }
 
 /// Errors related to [`AutoloadInfo`].
@@ -97,7 +97,7 @@ impl AutoloadInfo {
         match self.base_address {
             0x1ff8000 => AutoloadKind::Itcm,
             0x27e0000 | 0x27c0000 => AutoloadKind::Dtcm,
-            _ => AutoloadKind::Unknown,
+            _ => AutoloadKind::Unknown(*self),
         }
     }
 
@@ -130,7 +130,7 @@ impl Display for AutoloadKind {
         match self {
             AutoloadKind::Itcm => write!(f, "ITCM"),
             AutoloadKind::Dtcm => write!(f, "DTCM"),
-            AutoloadKind::Unknown => write!(f, "Unknown"),
+            AutoloadKind::Unknown(_) => write!(f, "Unknown"),
         }
     }
 }

--- a/lib/src/rom/raw/rom.rs
+++ b/lib/src/rom/raw/rom.rs
@@ -89,16 +89,12 @@ impl<'a> Rom<'a> {
             header.arm9_build_info_offset
         };
 
-        Ok(Arm9::new(
-            Cow::Borrowed(data),
-            header.version(),
-            Arm9Offsets {
-                base_address: header.arm9.base_addr,
-                entry_function: header.arm9.entry,
-                build_info: build_info_offset,
-                autoload_callback: header.arm9_autoload_callback,
-            },
-        )?)
+        Ok(Arm9::new(Cow::Borrowed(data), Arm9Offsets {
+            base_address: header.arm9.base_addr,
+            entry_function: header.arm9.entry,
+            build_info: build_info_offset,
+            autoload_callback: header.arm9_autoload_callback,
+        })?)
     }
 
     /// Returns a reference to the ARM9 footer of this [`Rom`].
@@ -170,15 +166,12 @@ impl<'a> Rom<'a> {
         let build_info_offset =
             if header.arm7_build_info_offset == 0 { 0 } else { header.arm7_build_info_offset - header.arm7.offset };
 
-        Ok(Arm7::new(
-            Cow::Borrowed(data),
-            Arm7Offsets {
-                base_address: header.arm7.base_addr,
-                entry_function: header.arm7.entry,
-                build_info: build_info_offset,
-                autoload_callback: header.arm7_autoload_callback,
-            },
-        ))
+        Ok(Arm7::new(Cow::Borrowed(data), Arm7Offsets {
+            base_address: header.arm7.base_addr,
+            entry_function: header.arm7.entry,
+            build_info: build_info_offset,
+            autoload_callback: header.arm7_autoload_callback,
+        }))
     }
 
     /// Returns the ARM7 overlay table of this [`Rom`].

--- a/lib/src/rom/rom.rs
+++ b/lib/src/rom/rom.rs
@@ -17,6 +17,7 @@ use super::{
     Overlay, OverlayInfo, RomConfigAutoload,
 };
 use crate::{
+    compress::lz77::Lz77DecompressError,
     crypto::blowfish::BlowfishKey,
     io::{create_dir_all, create_file, create_file_and_dirs, open_file, read_file, read_to_string, FileError},
     rom::{raw::FileAlloc, Arm9WithTcmsOptions, RomConfig},
@@ -195,6 +196,12 @@ pub enum RomSaveError {
     BannerImage {
         /// Source error.
         source: BannerImageError,
+    },
+    /// See [`Lz77DecompressError`].
+    #[snafu(transparent)]
+    Lz77Decompress {
+        /// Source error.
+        source: Lz77DecompressError,
     },
 }
 
@@ -471,7 +478,7 @@ impl<'a> Rom<'a> {
 
                 if plain_overlay.is_compressed() {
                     log::info!("Decompressing {processor} overlay {}/{}", overlay.id(), overlays.len() - 1);
-                    plain_overlay.decompress();
+                    plain_overlay.decompress()?;
                 }
                 create_file(overlays_path.join(format!("{name}.bin")))?.write(plain_overlay.code())?;
             }

--- a/lib/src/rom/rom.rs
+++ b/lib/src/rom/rom.rs
@@ -14,7 +14,7 @@ use super::{
     },
     Arm7, Arm9, Arm9AutoloadError, Arm9Error, Arm9Offsets, Autoload, Banner, BannerError, BannerImageError, BuildInfo,
     FileBuildError, FileParseError, FileSystem, Header, HeaderBuildError, Logo, LogoError, LogoLoadError, LogoSaveError,
-    Overlay, OverlayInfo,
+    Overlay, OverlayInfo, RomConfigAutoload,
 };
 use crate::{
     crypto::blowfish::BlowfishKey,
@@ -86,6 +86,24 @@ pub enum RomExtractError {
     RawArm9 {
         /// Source error.
         source: RawArm9Error,
+    },
+    /// See [`Arm9AutoloadError`]
+    #[snafu(transparent)]
+    Arm9Autoload {
+        /// Source error.
+        source: Arm9AutoloadError,
+    },
+    /// See [`RawBuildInfoError`].
+    #[snafu(transparent)]
+    RawBuildInfo {
+        /// Source error.
+        source: RawBuildInfoError,
+    },
+    /// See [`Arm9Error`].
+    #[snafu(transparent)]
+    Arm9 {
+        /// Source error.
+        source: Arm9Error,
     },
 }
 
@@ -226,20 +244,30 @@ impl<'a> Rom<'a> {
         let arm9_build_config: Arm9BuildConfig = serde_yml::from_reader(open_file(path.join(&config.arm9_config))?)?;
         let arm9 = read_file(path.join(&config.arm9_bin))?;
 
-        // --------------------- Load ITCM, DTCM ---------------------
-        let itcm = read_file(path.join(&config.itcm_bin))?;
-        let itcm_info = serde_yml::from_reader(open_file(path.join(&config.itcm_config))?)?;
-        let itcm = Autoload::new(itcm, itcm_info);
+        // --------------------- Load autoloads ---------------------
+        let mut autoloads = vec![];
 
-        let dtcm = read_file(path.join(&config.dtcm_bin))?;
-        let dtcm_info = serde_yml::from_reader(open_file(path.join(&config.dtcm_config))?)?;
+        let itcm = read_file(path.join(&config.itcm.bin))?;
+        let itcm_info = serde_yml::from_reader(open_file(path.join(&config.itcm.config))?)?;
+        let itcm = Autoload::new(itcm, itcm_info);
+        autoloads.push(itcm);
+
+        let dtcm = read_file(path.join(&config.dtcm.bin))?;
+        let dtcm_info = serde_yml::from_reader(open_file(path.join(&config.dtcm.config))?)?;
         let dtcm = Autoload::new(dtcm, dtcm_info);
+        autoloads.push(dtcm);
+
+        for unknown_autoload in &config.unknown_autoloads {
+            let autoload = read_file(path.join(&unknown_autoload.bin))?;
+            let autoload_info = serde_yml::from_reader(open_file(path.join(&unknown_autoload.config))?)?;
+            let autoload = Autoload::new(autoload, autoload_info);
+            autoloads.push(autoload);
+        }
 
         // --------------------- Build ARM9 program ---------------------
-        let mut arm9 = Arm9::with_two_tcms(
+        let mut arm9 = Arm9::with_autoloads(
             arm9,
-            itcm,
-            dtcm,
+            &autoloads,
             header.version(),
             arm9_build_config.offsets,
             Arm9WithTcmsOptions {
@@ -359,12 +387,16 @@ impl<'a> Rom<'a> {
         }
         create_file_and_dirs(path.join(&self.config.arm9_bin))?.write(plain_arm9.code()?)?;
 
-        // --------------------- Save ITCM, DTCM ---------------------
+        // --------------------- Save autoloads ---------------------
+        let mut unknown_autoloads = self.config.unknown_autoloads.iter();
         for autoload in plain_arm9.autoloads()?.iter() {
             let (bin_path, config_path) = match autoload.kind() {
-                raw::AutoloadKind::Itcm => (path.join(&self.config.itcm_bin), path.join(&self.config.itcm_config)),
-                raw::AutoloadKind::Dtcm => (path.join(&self.config.dtcm_bin), path.join(&self.config.dtcm_config)),
-                raw::AutoloadKind::Unknown => panic!("unknown autoload block"),
+                raw::AutoloadKind::Itcm => (path.join(&self.config.itcm.bin), path.join(&self.config.itcm.config)),
+                raw::AutoloadKind::Dtcm => (path.join(&self.config.dtcm.bin), path.join(&self.config.dtcm.config)),
+                raw::AutoloadKind::Unknown(_) => {
+                    let unknown_autoload = unknown_autoloads.next().expect("no more autoloads in config, was it removed?");
+                    (path.join(&unknown_autoload.bin), path.join(&unknown_autoload.config))
+                }
             };
             create_file_and_dirs(bin_path)?.write(autoload.code())?;
             serde_yml::to_writer(create_file_and_dirs(config_path)?, autoload.info())?;
@@ -466,6 +498,22 @@ impl<'a> Rom<'a> {
         let arm7_overlays =
             rom.arm7_overlay_table()?.iter().map(|ov| Overlay::parse(ov, fat, rom)).collect::<Result<Vec<_>, _>>()?;
 
+        let arm9 = rom.arm9()?;
+
+        let num_unknown_autoloads = if arm9.is_compressed()? {
+            let mut decompressed_arm9 = arm9.clone();
+            decompressed_arm9.decompress()?;
+            decompressed_arm9.num_unknown_autoloads()?
+        } else {
+            arm9.num_unknown_autoloads()?
+        };
+        let unknown_autoloads = (0..num_unknown_autoloads)
+            .map(|index| RomConfigAutoload {
+                bin: format!("arm9/unk_autoload_{index}.bin").into(),
+                config: format!("arm9/unk_autoload_{index}.yaml").into(),
+            })
+            .collect();
+
         let config = RomConfig {
             padding_value: rom.padding_value()?,
             header: "header.yaml".into(),
@@ -474,10 +522,9 @@ impl<'a> Rom<'a> {
             arm9_config: "arm9/arm9.yaml".into(),
             arm7_bin: "arm7/arm7.bin".into(),
             arm7_config: "arm7/arm7.yaml".into(),
-            itcm_bin: "arm9/itcm.bin".into(),
-            itcm_config: "arm9/itcm.yaml".into(),
-            dtcm_bin: "arm9/dtcm.bin".into(),
-            dtcm_config: "arm9/dtcm.yaml".into(),
+            itcm: RomConfigAutoload { bin: "arm9/itcm.bin".into(), config: "arm9/itcm.yaml".into() },
+            unknown_autoloads,
+            dtcm: RomConfigAutoload { bin: "arm9/dtcm.bin".into(), config: "arm9/dtcm.yaml".into() },
             arm9_overlays: if arm9_overlays.is_empty() { None } else { Some("arm9_overlays/overlays.yaml".into()) },
             arm7_overlays: if arm7_overlays.is_empty() { None } else { Some("arm7_overlays/overlays.yaml".into()) },
             banner: "banner/banner.yaml".into(),
@@ -488,7 +535,7 @@ impl<'a> Rom<'a> {
         Ok(Self {
             header: Header::load_raw(&header),
             header_logo: Logo::decompress(&header.logo)?,
-            arm9: rom.arm9()?,
+            arm9,
             arm9_overlays,
             arm7: rom.arm7()?,
             arm7_overlays,

--- a/lib/tests/roms/.gitignore
+++ b/lib/tests/roms/.gitignore
@@ -1,0 +1,3 @@
+*.nds
+*/
+arm7_bios.bin

--- a/lib/tests/roms/README.md
+++ b/lib/tests/roms/README.md
@@ -1,0 +1,3 @@
+Put some `*.nds` files in here and run `cargo test --release -- --nocapture` to test if `ds-rom` can extract and rebuild matching ROMs.
+
+Also put `arm7_bios.bin` (SHA1 `6ee830c7f552c5bf194c20a2c13d5bb44bdb5c03`), which you can [extract from your DS device](https://wiki.ds-homebrew.com/ds-index/ds-bios-firmware-dump).

--- a/lib/tests/test_extract_build.rs
+++ b/lib/tests/test_extract_build.rs
@@ -25,9 +25,12 @@ fn test_extract_build() -> Result<()> {
         if path.extension() != Some(OsStr::new("nds")) {
             continue;
         }
+        let file_name = path.file_name().unwrap().to_string_lossy();
+        if file_name.starts_with("build_") {
+            continue;
+        }
 
         // Extract
-        let file_name = path.file_name().unwrap().to_string_lossy();
         let extension = path.extension().unwrap().to_string_lossy();
         let base_name = file_name.strip_suffix(extension.as_ref()).unwrap().strip_suffix(".").unwrap();
         let extract_path = roms_dir.join(base_name);

--- a/lib/tests/test_extract_build.rs
+++ b/lib/tests/test_extract_build.rs
@@ -1,0 +1,57 @@
+use std::{ffi::OsStr, fs};
+
+use anyhow::Result;
+use ds_rom::{
+    crypto::blowfish::BlowfishKey,
+    rom::{raw, Rom},
+};
+use log::LevelFilter;
+
+#[test]
+fn test_extract_build() -> Result<()> {
+    env_logger::builder().filter_level(LevelFilter::Info).init();
+
+    let cwd = std::env::current_dir()?;
+    let roms_dir = cwd.join("tests/roms/");
+    let arm7_bios = roms_dir.join("arm7_bios.bin");
+    assert!(arm7_bios.exists());
+    assert!(arm7_bios.is_file());
+
+    let key = BlowfishKey::from_arm7_bios_path(arm7_bios)?;
+
+    for entry in roms_dir.read_dir()? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.extension() != Some(OsStr::new("nds")) {
+            continue;
+        }
+
+        // Extract
+        let file_name = path.file_name().unwrap().to_string_lossy();
+        let extension = path.extension().unwrap().to_string_lossy();
+        let base_name = file_name.strip_suffix(extension.as_ref()).unwrap().strip_suffix(".").unwrap();
+        let extract_path = roms_dir.join(base_name);
+
+        let raw_rom = raw::Rom::from_file(&path)?;
+        let rom = Rom::extract(&raw_rom)?;
+        rom.save(&extract_path, Some(&key))?;
+
+        // Build
+        let build_path = path.with_file_name(format!("build_{file_name}"));
+        let config_path = extract_path.join("config.yaml");
+
+        let rom = Rom::load(&config_path, Default::default())?;
+        let raw_rom = rom.build(Some(&key))?;
+        raw_rom.save(&build_path)?;
+
+        // Compare
+        let target = fs::read(&path)?;
+        let build = fs::read(&build_path)?;
+        assert!(target == build);
+
+        // Delete
+        fs::remove_file(&build_path)?;
+        fs::remove_dir_all(&extract_path)?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
Some games contain additional autoload blocks other than the TCMs. I've now added support for these by adding an `unknown_autoloads` field in the config YAML.

I also redesigned the LZ77 code compression implementation and I now believe that it is close to, if not the same as, the original algorithm. It now accounts for a much simpler set of edge cases instead of a bunch of strange-looking ones. The code also looks a bit more like Rust and a lot less like C :p

Closes #5