### PR TITLE
Handle additional error case for truncated or absent multiboot signature

### DIFF
--- a/lib/src/rom/raw/rom.rs
+++ b/lib/src/rom/raw/rom.rs
@@ -319,6 +319,7 @@ impl<'a> Rom<'a> {
             Ok(s) => Ok(Some(s)),
             Err(RawMultibootSignatureError::InvalidMagic { .. }) => Ok(None), // signature not found
             Err(RawMultibootSignatureError::Misaligned { .. }) => Ok(None),   // not aligned by 4
+            Err(RawMultibootSignatureError::DataTooSmall { .. }) => Ok(None), // signature truncated or absent at EOF
             Err(e) => Err(e),
         }
     }


### PR DESCRIPTION
Single line PR that adds a match arm for `RawMultibootSignatureError::DataTooSmall` errors. I had some issues with extraction failing for ROMs built by ndstool. It's likely ndstool destroys the multiboot signature. I think it's reasonable to continue extraction here especially since the other error types do the same.