### PR TITLE
Speedup loading Rom from directory of files

### DIFF
--- a/lib/src/rom/file.rs
+++ b/lib/src/rom/file.rs
@@ -96,15 +96,21 @@ impl<'a> FileSystem<'a> {
 
     fn load_in<P: AsRef<Path>>(&mut self, path: P, parent_id: u16) -> Result<(), FileError> {
         // Sort children by FNT order so the file/dir IDs become correct
-        let mut children =
-            read_dir(&path)?.collect::<Result<Vec<_>, _>>()?.into_iter().map(|entry| entry.path()).collect::<Vec<_>>();
-        children.sort_unstable_by(|a, b| {
-            Self::compare_for_fnt(a.to_string_lossy().as_ref(), a.is_dir(), b.to_string_lossy().as_ref(), b.is_dir())
-        });
+        let mut children = read_dir(&path)?
+            .collect::<Result<Vec<_>, _>>()?
+            .into_iter()
+            .map(|entry| entry.path())
+            .map(|child| {
+                let as_string = child.to_string_lossy().to_string();
+                let is_dir = child.is_dir();
+                (child, as_string, is_dir)
+            })
+            .collect::<Vec<_>>();
+        children.sort_unstable_by(|a, b| Self::compare_for_fnt(&a.1, a.2, &b.1, b.2));
 
-        for child in children.into_iter() {
+        for (child, _, is_dir) in children.into_iter() {
             let name = child.file_name().unwrap().to_string_lossy().to_string();
-            if child.is_dir() {
+            if is_dir {
                 let child_id = self.next_dir_id;
                 let child_path = path.as_ref().join(&name);
                 self.make_child_dir(name, parent_id);


### PR DESCRIPTION
Changes `Rom::load_in` to create filepath strings and check for directories upfront instead of during the comparison function. This avoids redundant syscalls and allocations, since the comparison function is called many times per entry during sorting.

This reduces the runtime of creating a rom file from a directory of files by ~75%.

## Context
I'm writing a modding tool for the game Dragon Quest Monsters: Joker. Currently it takes a few seconds to pack a ROM after making changes to files within it. I wanted to speed it up so the user doesn't have to wait as long for it to pack.

## Performance
Tested on my desktop computer

* **OS:** Windows 11 (Version: 25H2, OS build: 26200.8457)
* **Processor:** AMD Ryzen 5 3600 6-Core Processor (3.59 GHz)
* **Storage device:** Samsung SSD 980 PRO 2TB (M.2 NVME)

The timed portion of the benchmark runs `load`, `build`, and `save` on the unpacked files of the North American ROM for Dragon Quest Monsters: Joker. The directory has 3294 files (totaling 82.65 MB).

The statistics below are from 100 runs of the benchmark.

| Stat | Before | After | Reduction |
|--|--|--|--|
| Mean | 2.52s | 0.62s | 75.52% |
| Std dev | 0.018s | 0.011s | - |

### Benchmark
Compiled with `--release`

```rust
use std::{path::Path, time::Instant};

use ds_rom::rom::{raw, Rom, RomLoadOptions};

fn setup(rom_filepath: &str, output_directory: &Path) {
    let raw_rom = raw::Rom::from_file(rom_filepath).unwrap();
    let rom = Rom::extract(&raw_rom).unwrap();
    rom.save(output_directory, None).unwrap();
}

fn main() {
    let rom_filepath = "..."; // actual filepaths omitted
    let output_directory = Path::new("...");
    let rom_output_filepath = "...";

    setup(rom_filepath, output_directory);

    let config_filepath = output_directory.join("config.yaml");

    let now = Instant::now();
    let rom = Rom::load(config_filepath, RomLoadOptions::default()).unwrap();
    let raw_rom = rom.build(None).unwrap();
    raw_rom.save(rom_output_filepath).unwrap();
    let elapsed = now.elapsed();

    let elapsed = elapsed.as_secs_f64();
    println!("{elapsed}");
}
```