### PR TITLE
Update to 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -340,6 +340,7 @@ dependencies = [
  "ds-rom",
  "env_logger",
  "log",
+ "serde-saphyr",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -313,7 +313,7 @@ dependencies = [
 
 [[package]]
 name = "ds-rom"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "bitfield-struct",
@@ -333,7 +333,7 @@ dependencies = [
 
 [[package]]
 name = "ds-rom-cli"
-version = "0.7.0"
+version = "0.7.1"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -345,7 +345,7 @@ dependencies = [
 
 [[package]]
 name = "ds-rom"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "bitfield-struct",
@@ -366,7 +366,7 @@ dependencies = [
 
 [[package]]
 name = "ds-rom-cli"
-version = "0.7.1"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "clap",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -302,6 +311,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +352,7 @@ dependencies = [
  "bitreader",
  "bytemuck",
  "crc",
+ "derive_more",
  "encoding_rs",
  "env_logger",
  "image",
@@ -700,6 +733,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -715,6 +757,12 @@ dependencies = [
  "smallvec",
  "thiserror",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "serde"
@@ -876,10 +924,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
+
+[[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "utf8parse"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,7 @@ resolver = "2"
 
 [profile.release]
 lto = true
+
+[profile.release-fast]
+inherits = "release"
+lto = false

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ds-rom-cli"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = ["Aetias <aetias@outlook.com>"]
 license = "MIT"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,3 +19,4 @@ clap = { version = "4.5.22", features = ["derive"] }
 ds-rom = { path = "../lib" }
 env_logger = "0.11.5"
 log = "0.4.22"
+serde-saphyr = "0.0"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ds-rom-cli"
 version = "0.7.1"
-edition = "2021"
+edition = "2024"
 authors = ["Aetias <aetias@outlook.com>"]
 license = "MIT"
 repository = "https://github.com/AetiasHax/ds-rom"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ds-rom-cli"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 authors = ["Aetias <aetias@outlook.com>"]
 license = "MIT"

--- a/cli/src/build.rs
+++ b/cli/src/build.rs
@@ -1,6 +1,6 @@
 use std::path::PathBuf;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use clap::Args;
 use ds_rom::{
     crypto::blowfish::BlowfishKey,
@@ -29,8 +29,11 @@ pub struct Build {
 
 impl Build {
     pub fn run(&self) -> Result<()> {
-        let key =
-            if let Some(arm7_bios) = &self.arm7_bios { Some(BlowfishKey::from_arm7_bios_path(arm7_bios)?) } else { None };
+        let key = if let Some(arm7_bios) = &self.arm7_bios {
+            Some(BlowfishKey::from_arm7_bios_path(arm7_bios)?)
+        } else {
+            None
+        };
 
         let options = RomLoadOptions { key: key.as_ref(), compress: !self.no_compress, ..Default::default() };
         let rom = match Rom::load(&self.config, options) {

--- a/cli/src/dump.rs
+++ b/cli/src/dump.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::{collections::HashMap, path::PathBuf};
 
 use anyhow::{bail, Context, Result};
 use clap::{Args, Subcommand};
@@ -77,6 +77,7 @@ impl Dump {
             DumpCommand::Arm9OverlaySignatures(dump_arm9_overlay_signatures) => dump_arm9_overlay_signatures.run(&rom),
             DumpCommand::MultibootSignature(dump_multiboot_signature) => dump_multiboot_signature.run(&rom),
             DumpCommand::Libraries(dump_libraries) => dump_libraries.run(&rom),
+            DumpCommand::DsProt(dump_dsprot) => dump_dsprot.run(&rom),
         }
     }
 }
@@ -109,6 +110,8 @@ enum DumpCommand {
     MultibootSignature(DumpMultibootSignature),
     #[command(name = "libs")]
     Libraries(DumpLibraries),
+    #[command(name = "dsprot")]
+    DsProt(DumpDsProt),
 }
 
 /// Shows the contents of the ROM header.
@@ -534,6 +537,57 @@ impl DumpLibraries {
         }
         for library in libraries {
             println!("{}", library.display(2));
+        }
+
+        Ok(())
+    }
+}
+
+/// Prints information about DS Protect usage.
+#[derive(Args)]
+pub struct DumpDsProt {
+    #[arg(long)]
+    yaml: bool,
+}
+
+impl DumpDsProt {
+    pub fn run(&self, raw_rom: &raw::Rom) -> Result<()> {
+        let mut rom = Rom::extract(raw_rom)?;
+
+        let arm9 = rom.arm9_mut();
+        arm9.decompress()?;
+        for overlay in rom.arm9_overlays_mut() {
+            overlay.decompress()?;
+        }
+
+        let arm9 = rom.arm9_mut();
+        if !self.yaml {
+            if let Some(dsprot_info) = arm9.dsprot_info()? {
+                println!("DS Protect found in ARM9 main:\n{}", dsprot_info.display(2));
+                if let Some(details) = arm9.decrypt_dsprot()? {
+                    println!("Result from decryption:\n{}", details.display(2));
+                }
+            }
+
+            for overlay in rom.arm9_overlays_mut() {
+                if let Some(dsprot_info) = overlay.dsprot_info()? {
+                    println!("DS Protect found in ARM9 overlay {}:\n{}", overlay.id(), dsprot_info.display(2));
+                    if let Some(details) = overlay.decrypt_dsprot()? {
+                        println!("Result from decryption:\n{}", details.display(2));
+                    }
+                }
+            }
+        } else {
+            let mut details_list = HashMap::new();
+            if let Some(details) = arm9.decrypt_dsprot()? {
+                details_list.insert("arm9".to_string(), details);
+            }
+            for overlay in rom.arm9_overlays_mut() {
+                if let Some(details) = overlay.decrypt_dsprot()? {
+                    details_list.insert(format!("ov{:03}", overlay.id()), details);
+                }
+            }
+            serde_saphyr::to_io_writer(&mut std::io::stdout().lock(), &details_list)?;
         }
 
         Ok(())

--- a/cli/src/dump.rs
+++ b/cli/src/dump.rs
@@ -1,11 +1,11 @@
 use std::{collections::HashMap, path::PathBuf};
 
-use anyhow::{bail, Context, Result};
+use anyhow::{Context, Result, bail};
 use clap::{Args, Subcommand};
 use ds_rom::{
     compress::lz77::Lz77,
-    crypto::{blowfish::BlowfishKey, hmac_sha1::HmacSha1},
-    rom::{self, raw, Arm9, Logo, Overlay, Rom},
+    crypto::{blowfish::BlowfishKey, dsprot::DecryptOptions, hmac_sha1::HmacSha1},
+    rom::{self, Arm9, Logo, Overlay, Rom, raw},
 };
 
 use crate::print_hex;
@@ -560,11 +560,13 @@ impl DumpDsProt {
             overlay.decompress()?;
         }
 
+        let options = DecryptOptions { decode_literals: true };
+
         let arm9 = rom.arm9_mut();
         if !self.yaml {
             if let Some(dsprot_info) = arm9.dsprot_info()? {
                 println!("DS Protect found in ARM9 main:\n{}", dsprot_info.display(2));
-                if let Some(details) = arm9.decrypt_dsprot()? {
+                if let Some(details) = arm9.decrypt_dsprot(&options)? {
                     println!("Result from decryption:\n{}", details.display(2));
                 }
             }
@@ -572,18 +574,18 @@ impl DumpDsProt {
             for overlay in rom.arm9_overlays_mut() {
                 if let Some(dsprot_info) = overlay.dsprot_info()? {
                     println!("DS Protect found in ARM9 overlay {}:\n{}", overlay.id(), dsprot_info.display(2));
-                    if let Some(details) = overlay.decrypt_dsprot()? {
+                    if let Some(details) = overlay.decrypt_dsprot(&options)? {
                         println!("Result from decryption:\n{}", details.display(2));
                     }
                 }
             }
         } else {
             let mut details_list = HashMap::new();
-            if let Some(details) = arm9.decrypt_dsprot()? {
+            if let Some(details) = arm9.decrypt_dsprot(&options)? {
                 details_list.insert("arm9".to_string(), details);
             }
             for overlay in rom.arm9_overlays_mut() {
-                if let Some(details) = overlay.decrypt_dsprot()? {
+                if let Some(details) = overlay.decrypt_dsprot(&options)? {
                     details_list.insert(format!("ov{:03}", overlay.id()), details);
                 }
             }

--- a/cli/src/dump.rs
+++ b/cli/src/dump.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result, bail};
 use clap::{Args, Subcommand};
 use ds_rom::{
     compress::lz77::Lz77,
-    crypto::{blowfish::BlowfishKey, dsprot::DecryptOptions, hmac_sha1::HmacSha1},
+    crypto::{blowfish::BlowfishKey, dsprot::DsProtDecryptOptions, hmac_sha1::HmacSha1},
     rom::{self, Arm9, Logo, Overlay, Rom, raw},
 };
 
@@ -560,7 +560,7 @@ impl DumpDsProt {
             overlay.decompress()?;
         }
 
-        let options = DecryptOptions { decode_literals: true };
+        let options = DsProtDecryptOptions { decode_relocations: true };
 
         let arm9 = rom.arm9_mut();
         if !self.yaml {

--- a/cli/src/dump.rs
+++ b/cli/src/dump.rs
@@ -39,8 +39,11 @@ pub struct Dump {
 
 impl Dump {
     pub fn run(&self) -> Result<()> {
-        let key =
-            if let Some(arm7_bios) = &self.arm7_bios { Some(BlowfishKey::from_arm7_bios_path(arm7_bios)?) } else { None };
+        let key = if let Some(arm7_bios) = &self.arm7_bios {
+            Some(BlowfishKey::from_arm7_bios_path(arm7_bios)?)
+        } else {
+            None
+        };
 
         let rom = raw::Rom::from_file(self.rom.clone())?;
         let header = rom.header()?;

--- a/cli/src/dump.rs
+++ b/cli/src/dump.rs
@@ -581,11 +581,11 @@ impl DumpDsProt {
             }
         } else {
             let mut details_list = HashMap::new();
-            if let Some(details) = arm9.decrypt_dsprot(&options)? {
+            if let Some(details) = arm9.decrypt_dsprot(&options)?.cloned() {
                 details_list.insert("arm9".to_string(), details);
             }
             for overlay in rom.arm9_overlays_mut() {
-                if let Some(details) = overlay.decrypt_dsprot(&options)? {
+                if let Some(details) = overlay.decrypt_dsprot(&options)?.cloned() {
                     details_list.insert(format!("ov{:03}", overlay.id()), details);
                 }
             }

--- a/cli/src/dump.rs
+++ b/cli/src/dump.rs
@@ -564,19 +564,13 @@ impl DumpDsProt {
 
         let arm9 = rom.arm9_mut();
         if !self.yaml {
-            if let Some(dsprot_info) = arm9.dsprot_info()? {
-                println!("DS Protect found in ARM9 main:\n{}", dsprot_info.display(2));
-                if let Some(details) = arm9.decrypt_dsprot(&options)? {
-                    println!("Result from decryption:\n{}", details.display(2));
-                }
+            if let Some(dsprot_result) = arm9.dsprot_state().as_option() {
+                println!("DS Protect found in ARM9 main:\n{}", dsprot_result.display(2));
             }
 
             for overlay in rom.arm9_overlays_mut() {
-                if let Some(dsprot_info) = overlay.dsprot_info()? {
-                    println!("DS Protect found in ARM9 overlay {}:\n{}", overlay.id(), dsprot_info.display(2));
-                    if let Some(details) = overlay.decrypt_dsprot(&options)? {
-                        println!("Result from decryption:\n{}", details.display(2));
-                    }
+                if let Some(dsprot_result) = overlay.dsprot_state().as_option() {
+                    println!("DS Protect found in ARM9 overlay {}:\n{}", overlay.id(), dsprot_result.display(2));
                 }
             }
         } else {

--- a/cli/src/extract.rs
+++ b/cli/src/extract.rs
@@ -1,10 +1,10 @@
 use std::path::PathBuf;
 
-use anyhow::{bail, Result};
+use anyhow::{Result, bail};
 use clap::Args;
 use ds_rom::{
     crypto::blowfish::BlowfishKey,
-    rom::{raw, Rom, RomSaveError},
+    rom::{Rom, RomSaveError, raw},
 };
 
 /// Extracts a ROM to a given path
@@ -26,8 +26,11 @@ pub struct Extract {
 impl Extract {
     pub fn run(&self) -> Result<()> {
         let raw_rom = raw::Rom::from_file(&self.rom)?;
-        let key =
-            if let Some(arm7_bios) = &self.arm7_bios { Some(BlowfishKey::from_arm7_bios_path(arm7_bios)?) } else { None };
+        let key = if let Some(arm7_bios) = &self.arm7_bios {
+            Some(BlowfishKey::from_arm7_bios_path(arm7_bios)?)
+        } else {
+            None
+        };
         let rom = Rom::extract(&raw_rom)?;
 
         match rom.save(&self.path, key.as_ref()) {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -16,6 +16,9 @@ use log::LevelFilter;
 struct Cli {
     #[command(subcommand)]
     command: Command,
+
+    #[arg(long)]
+    debug: bool,
 }
 
 #[derive(Subcommand)]
@@ -36,9 +39,9 @@ impl Command {
 }
 
 fn main() -> Result<()> {
-    env_logger::builder().filter_level(LevelFilter::Info).init();
-
     let args: Cli = Cli::parse();
+    env_logger::builder().filter_level(if args.debug { LevelFilter::Debug } else { LevelFilter::Info }).init();
+
     args.command.run()
 }
 

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -54,6 +54,11 @@ pub fn print_hex(data: &[u8], raw: bool, base: u32) -> Result<()> {
             for byte in chunk {
                 print!(" {byte:02x}");
             }
+            print!("  ");
+            for &byte in chunk {
+                let ch = char::from(byte);
+                print!("{}", if ch.is_ascii_graphic() { ch } else { '.' });
+            }
             println!();
         }
     }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -54,6 +54,9 @@ pub fn print_hex(data: &[u8], raw: bool, base: u32) -> Result<()> {
             for byte in chunk {
                 print!(" {byte:02x}");
             }
+            for _ in chunk.len()..16 {
+                print!("   ");
+            }
             print!("  ");
             for &byte in chunk {
                 let ch = char::from(byte);

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ds-rom"
-version = "0.7.0"
+version = "0.7.1"
 edition = "2021"
 authors = ["Aetias <aetias@outlook.com>"]
 license = "MIT"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ds-rom"
 version = "0.7.1"
-edition = "2021"
+edition = "2024"
 authors = ["Aetias <aetias@outlook.com>"]
 license = "MIT"
 repository = "https://github.com/AetiasHax/ds-rom"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ds-rom"
-version = "0.7.1"
+version = "0.8.0"
 edition = "2024"
 authors = ["Aetias <aetias@outlook.com>"]
 license = "MIT"

--- a/lib/Cargo.toml
+++ b/lib/Cargo.toml
@@ -13,6 +13,7 @@ bitfield-struct = "0.12"
 bitreader = "0.3"
 bytemuck = { version = "1.25", features = ["derive"] }
 crc = "3.4"
+derive_more = { version = "2.1", features = ["display"] }
 encoding_rs = "0.8"
 image = { version = "0.25", default-features = false, features = ["png"] }
 log = "0.4"

--- a/lib/src/compress/lz77.rs
+++ b/lib/src/compress/lz77.rs
@@ -236,9 +236,7 @@ pub enum Lz77ParseError {
         backtrace: Backtrace,
     },
     /// Occurs when a length-distance pair would point to data that is not within the decompressed stream.
-    #[snafu(display(
-        "length-distance pair {pair} at offset {offset:#x} points outside of decompressed stream:\n{backtrace}"
-    ))]
+    #[snafu(display("length-distance pair {pair} at offset {offset:#x} points outside of decompressed stream:\n{backtrace}"))]
     OutOfBounds {
         /// The erroneous length-distance pair.
         pair: Pair,

--- a/lib/src/crypto/blowfish.rs
+++ b/lib/src/crypto/blowfish.rs
@@ -7,7 +7,7 @@ use std::{
 use bytemuck::{Pod, Zeroable};
 use snafu::{Backtrace, Snafu};
 
-use crate::io::{open_file, FileError};
+use crate::io::{FileError, open_file};
 
 /// De/encrypts data using the [Blowfish](https://en.wikipedia.org/wiki/Blowfish_(cipher)) block cipher.
 #[repr(C)]

--- a/lib/src/crypto/dsprot.rs
+++ b/lib/src/crypto/dsprot.rs
@@ -215,6 +215,20 @@ pub enum DsProtError {
     },
 }
 
+/// Options for [`DsProtInfo::decrypt`].
+#[derive(Clone)]
+pub struct DecryptOptions {
+    /// If true, pointers and constants will be decoded. This applies to constant pools and global
+    /// variables managed by DS Protect.
+    ///
+    /// Pointers are decoded by subtracting the reference offset value based on the DS Protect
+    /// version.
+    ///
+    /// Constants are decoded by subtracting the reference offset and the address of an unused BSS
+    /// variable owned by DS Protect.
+    pub decode_literals: bool,
+}
+
 impl DsProtInfo {
     /// Searches for DS Protect usage in the provided module.
     pub fn detect(data: &[u8]) -> Option<Self> {
@@ -238,13 +252,24 @@ impl DsProtInfo {
     ///
     /// This function will return an error if it accesses data out of bounds. This happens if the
     /// wrong data is passed, or due to a bug in this function.
-    pub fn decrypt(&self, data: &mut [u8], base_address: u32) -> Result<DsProtDecryptDetails, DsProtError> {
+    pub fn decrypt(
+        &self,
+        data: &mut [u8],
+        base_address: u32,
+        options: &DecryptOptions,
+    ) -> Result<DsProtDecryptDetails, DsProtError> {
         let end_address = base_address + data.len() as u32;
 
         // Make 32-bit chunks
         let words: &mut [u32] = bytemuck::cast_slice_mut(data);
 
-        self.version.algo.decrypt(words, &AlgoDecryptOptions { base_address, end_address, version: self.version.number })
+        let DecryptOptions { decode_literals } = options.clone();
+        self.version.algo.decrypt(words, &AlgoDecryptOptions {
+            base_address,
+            end_address,
+            version: self.version.number,
+            decode_literals,
+        })
     }
 
     /// Creates a [`DisplayDsProtInfo`] which implements [`Display`].
@@ -295,6 +320,7 @@ struct AlgoDecryptOptions {
     base_address: u32,
     end_address: u32,
     version: &'static str,
+    decode_literals: bool,
 }
 
 const DECRYPTION_WRAPPER_SIGNATURE_1: [u32; 3] = [0xe92d00f0, 0xe92d000f, 0xe8bd00f0];
@@ -397,7 +423,7 @@ trait DsProtAlgo {
     fn find_obfuscated_function_tables(
         &self,
         options: &AlgoDecryptOptions,
-        words: &mut [u32],
+        words: &[u32],
     ) -> Result<Vec<EncryptedFunction>, DsProtError> {
         let AlgoDecryptOptions { base_address, .. } = *options;
 
@@ -502,7 +528,7 @@ trait DsProtAlgo {
         dsprot_bss: u32,
         unkeyed_encrypted_functions: &mut [EncryptedFunction],
     ) -> Result<(Vec<EncryptedFunction>, Vec<EncodedFunctionPointer>), DsProtError> {
-        let AlgoDecryptOptions { base_address, end_address, .. } = *options;
+        let AlgoDecryptOptions { base_address, end_address, decode_literals, .. } = *options;
 
         let mut decryption_wrappers = Vec::new();
         let mut encoded_function_pointers = Vec::new();
@@ -545,14 +571,17 @@ trait DsProtAlgo {
                 let dest_func_address = pool_words[3] - reference_offset;
                 let garbage_address = pool_words[4] - reference_offset;
 
-                pool_words[0] = bss;
-                pool_words[1] = dest_func_size;
-                pool_words[2] = seed_key;
-                pool_words[3] = dest_func_address;
-                // sanity check that this looks like a RAM address
+                // Check that this looks like a RAM address
                 let with_garbage = garbage_address >> 24 == 0x02;
-                if with_garbage {
-                    pool_words[4] = garbage_address;
+
+                if decode_literals {
+                    pool_words[0] = bss;
+                    pool_words[1] = dest_func_size;
+                    pool_words[2] = seed_key;
+                    pool_words[3] = dest_func_address;
+                    if with_garbage {
+                        pool_words[4] = garbage_address;
+                    }
                 }
 
                 function.constant_pool = EncodedConstantPool::DecryptionWrapperType1 { with_garbage };
@@ -578,15 +607,18 @@ trait DsProtAlgo {
                 let wrapper_fragment = pool_words[5] - reference_offset;
                 let garbage_address = pool_words[6] - reference_offset;
 
-                pool_words[0] = bss;
-                pool_words[1] = seed_key;
-                pool_words[2] = dest_func_address;
-                pool_words[3] = dest_func_size;
-                pool_words[5] = wrapper_fragment;
-                // sanity check that this looks like a RAM address
+                // Check that this looks like a RAM address
                 let with_garbage = garbage_address >> 24 == 0x02;
-                if with_garbage {
-                    pool_words[6] = garbage_address;
+
+                if decode_literals {
+                    pool_words[0] = bss;
+                    pool_words[1] = seed_key;
+                    pool_words[2] = dest_func_address;
+                    pool_words[3] = dest_func_size;
+                    pool_words[5] = wrapper_fragment;
+                    if with_garbage {
+                        pool_words[6] = garbage_address;
+                    }
                 }
 
                 function.constant_pool = EncodedConstantPool::DecryptionWrapperType2 { with_garbage };
@@ -616,15 +648,18 @@ trait DsProtAlgo {
 
                 let wrapper_fragment_size = pool_words[5] >> 26;
 
-                pool_words[0] = bss;
-                pool_words[1] = seed_key_placeholder;
-                pool_words[2] = dest_func_address;
-                pool_words[3] = dest_func_size;
-                pool_words[5] = wrapper_fragment;
-                // sanity check that this looks like a RAM address
+                // Check that this looks like a RAM address
                 let with_garbage = garbage_address >> 24 == 0x02;
-                if with_garbage {
-                    pool_words[6] = garbage_address;
+
+                if decode_literals {
+                    pool_words[0] = bss;
+                    pool_words[1] = seed_key_placeholder;
+                    pool_words[2] = dest_func_address;
+                    pool_words[3] = dest_func_size;
+                    pool_words[5] = wrapper_fragment;
+                    if with_garbage {
+                        pool_words[6] = garbage_address;
+                    }
                 }
 
                 let seed_key = self.precalculated_seed_key().unwrap();
@@ -689,7 +724,7 @@ trait DsProtAlgo {
         dsprot_bss: u32,
         obfuscated_function_tables: &[EncryptedFunction],
     ) -> Result<Vec<EncryptedFunction>, DsProtError> {
-        let AlgoDecryptOptions { base_address, end_address, .. } = *options;
+        let AlgoDecryptOptions { base_address, end_address, decode_literals, .. } = *options;
 
         let mut encrypted_functions = Vec::new();
         for &EncryptedFunction { address: func_address, size: func_size, encryption: _, constant_pool } in
@@ -727,8 +762,10 @@ trait DsProtAlgo {
                 let func_size = *second - dsprot_bss - self.reference_offset();
                 log::debug!("Found unkeyed encrypted function at {:#010x}, size {:#x}", func_address, func_size);
 
-                *first = func_address;
-                *second = func_size;
+                if decode_literals {
+                    *first = func_address;
+                    *second = func_size;
+                }
 
                 encrypted_functions.push(EncryptedFunction {
                     address: func_address,
@@ -738,15 +775,17 @@ trait DsProtAlgo {
                 });
             }
 
-            // Decode pointer to garbage data
-            if with_garbage && let Some(next_chunk) = pool_iter.next() {
-                *next_chunk -= self.reference_offset();
-                log::debug!("Decoded garbage pointer after decoder function at {:#010x}", func_address);
-            }
-            // Decode pointer to this decoder function
-            if with_overwrite && let Some(next_chunk) = pool_iter.next() {
-                *next_chunk -= self.reference_offset();
-                log::debug!("Decoded overwrite pointer after decoder function at {:#010x}", func_address);
+            if decode_literals {
+                // Decode pointer to garbage data
+                if with_garbage && let Some(next_chunk) = pool_iter.next() {
+                    *next_chunk -= self.reference_offset();
+                    log::debug!("Decoded garbage pointer after decoder function at {:#010x}", func_address);
+                }
+                // Decode pointer to this decoder function
+                if with_overwrite && let Some(next_chunk) = pool_iter.next() {
+                    *next_chunk -= self.reference_offset();
+                    log::debug!("Decoded overwrite pointer after decoder function at {:#010x}", func_address);
+                }
             }
         }
         Ok(encrypted_functions)
@@ -758,7 +797,7 @@ trait DsProtAlgo {
         words: &mut [u32],
         decryption_wrappers: &mut [EncryptedFunction],
     ) -> Result<(), DsProtError> {
-        let AlgoDecryptOptions { base_address, end_address, .. } = *options;
+        let AlgoDecryptOptions { base_address, end_address, decode_literals, .. } = *options;
 
         for function in decryption_wrappers {
             let EncryptionType::Keyed(seed_key) = function.encryption else {
@@ -817,24 +856,28 @@ trait DsProtAlgo {
                 || func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f307c, 0xe59f207c]
             {
                 // Flashcart/Emulator detector
-                let test_fn_addr = pool_words[0] - reference_offset;
-                let integrity_fn_addr = pool_words[1] - reference_offset;
-                pool_words[0] = test_fn_addr;
-                pool_words[1] = integrity_fn_addr;
+                if decode_literals {
+                    let test_fn_addr = pool_words[0] - reference_offset;
+                    let integrity_fn_addr = pool_words[1] - reference_offset;
+                    pool_words[0] = test_fn_addr;
+                    pool_words[1] = integrity_fn_addr;
+                }
                 function.constant_pool = EncodedConstantPool::FlashcartEmulatorDetectorType1;
                 log::debug!("Decrypted flashcart/emulator detector (type 1)");
             } else if func_start[0..4] == [0xe92d4ff8, 0xe24dd098, 0xe59f2170, 0xe59f4170]
                 || func_start[0..4] == [0xe92d4ff8, 0xe24dd098, 0xe59f2174, 0xe59f4174]
             {
                 // Flashcart/Emulator detector
-                let callback_index_addr = pool_words[0] - reference_offset;
-                let callback_table_addr = pool_words[1] - reference_offset;
-                let test_fn_addr = pool_words[2] - reference_offset;
-                let integrity_fn_addr = pool_words[3] - reference_offset;
-                pool_words[0] = callback_index_addr;
-                pool_words[1] = callback_table_addr;
-                pool_words[2] = test_fn_addr;
-                pool_words[3] = integrity_fn_addr;
+                if decode_literals {
+                    let callback_index_addr = pool_words[0] - reference_offset;
+                    let callback_table_addr = pool_words[1] - reference_offset;
+                    let test_fn_addr = pool_words[2] - reference_offset;
+                    let integrity_fn_addr = pool_words[3] - reference_offset;
+                    pool_words[0] = callback_index_addr;
+                    pool_words[1] = callback_table_addr;
+                    pool_words[2] = test_fn_addr;
+                    pool_words[3] = integrity_fn_addr;
+                }
                 function.constant_pool = EncodedConstantPool::FlashcartEmulatorDetectorType2;
                 log::debug!("Decrypted flashcart/emulator detector (type 2)");
             } else if func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f3070, 0xe3a02000]
@@ -842,34 +885,42 @@ trait DsProtAlgo {
                 || func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f3080, 0xe3a02000]
             {
                 // Dummy detector
-                let test_fn_addr = pool_words[0] - reference_offset;
-                pool_words[0] = test_fn_addr;
+                if decode_literals {
+                    let test_fn_addr = pool_words[0] - reference_offset;
+                    pool_words[0] = test_fn_addr;
+                }
                 function.constant_pool = EncodedConstantPool::DummyDetector;
                 log::debug!("Decrypted dummy detector");
             } else if func_start[0..4] == [0xe92d4ff8, 0xe24dd018, 0xe59fa100, 0xe59f6100] {
                 // MAC and ROM integrity checkers
-                let mac_integrity_fn_addr = pool_words[0] - reference_offset;
-                let mac_test_fn_addr = pool_words[1] - reference_offset;
-                let rom_integrity_fn_addr = pool_words[2] - reference_offset;
-                let rom_test_fn_addr = pool_words[3] - reference_offset;
-                pool_words[0] = mac_integrity_fn_addr;
-                pool_words[1] = mac_test_fn_addr;
-                pool_words[2] = rom_integrity_fn_addr;
-                pool_words[3] = rom_test_fn_addr;
+                if decode_literals {
+                    let mac_integrity_fn_addr = pool_words[0] - reference_offset;
+                    let mac_test_fn_addr = pool_words[1] - reference_offset;
+                    let rom_integrity_fn_addr = pool_words[2] - reference_offset;
+                    let rom_test_fn_addr = pool_words[3] - reference_offset;
+                    pool_words[0] = mac_integrity_fn_addr;
+                    pool_words[1] = mac_test_fn_addr;
+                    pool_words[2] = rom_integrity_fn_addr;
+                    pool_words[3] = rom_test_fn_addr;
+                }
                 function.constant_pool = EncodedConstantPool::MacRomIntegrityChecker;
                 log::debug!("Decrypted MAC and ROM integrity checkers");
             } else if func_start[6] == 0x112fff1e {
                 // Integrity checkers
-                let checked_fn_addr = pool_words[0] - self.integrity_check_offset();
-                pool_words[0] = checked_fn_addr;
+                if decode_literals {
+                    let checked_fn_addr = pool_words[0] - self.integrity_check_offset();
+                    pool_words[0] = checked_fn_addr;
+                }
                 function.constant_pool = EncodedConstantPool::IntegrityChecker;
                 log::debug!("Decrypted integrity checker");
             } else if func_start[0..4] == [0xe1a0a00f, 0xe19aa00a, 0x102ee00e, 0xe25aa008] {
                 // Crash
-                let clear_fn_addr = pool_words[0] - reference_offset;
-                let terminate_fn_addr = pool_words[1] - reference_offset;
-                pool_words[0] = clear_fn_addr;
-                pool_words[1] = terminate_fn_addr;
+                if decode_literals {
+                    let clear_fn_addr = pool_words[0] - reference_offset;
+                    let terminate_fn_addr = pool_words[1] - reference_offset;
+                    pool_words[0] = clear_fn_addr;
+                    pool_words[1] = terminate_fn_addr;
+                }
                 function.constant_pool = EncodedConstantPool::Crash;
                 log::debug!("Decrypted crash function");
             }
@@ -884,6 +935,10 @@ trait DsProtAlgo {
         words: &mut [u32],
         encoded_function_pointers: &[EncodedFunctionPointer],
     ) -> Result<(), DsProtError> {
+        if !options.decode_literals {
+            return Ok(());
+        }
+
         let &AlgoDecryptOptions { base_address, end_address, .. } = options;
         for &encoded_fn_ptr in encoded_function_pointers.iter() {
             let Some(encoded_fn) = words.get_mut((encoded_fn_ptr.0 - base_address) as usize / 4) else {

--- a/lib/src/crypto/dsprot.rs
+++ b/lib/src/crypto/dsprot.rs
@@ -17,7 +17,7 @@ struct DsProtVersion {
 
 const DSPROT_VERSIONS: &[DsProtVersion] = &[
     DsProtVersion {
-        number: "1.00/2",
+        number: "1.00",
         detect_signature: [0xe3527270, 0xbafe77fc, 0xe59e0989, 0xe1c2f9af, 0xea018a51, 0xeb004ae2],
         algo: &DsProtAlgoV1 { encrypted_range_start_signature: [0xe92d0001, 0xe1a0000f, 0xe2800010, 0xe8bd0001, 0xea000000] },
     },
@@ -788,15 +788,10 @@ trait DsProtAlgo {
                 .fail();
             };
             let mut prev_ins = 0;
-            for (i, instruction) in func_words.iter_mut().enumerate() {
+            for instruction in func_words.iter_mut() {
                 let ins = *instruction;
                 *instruction = self.decrypt_instruction(&mut rc4, ins, prev_ins);
                 prev_ins = ins;
-
-                let options = unarm::Options::default();
-                let pc = function.address + i as u32 * 4;
-                let ins = unarm::parse_arm(*instruction, pc, &options);
-                println!("{:08x}  {:08x}  {}", pc, *instruction, ins.display(&options));
             }
 
             // Decrypt constant pools based on function signature

--- a/lib/src/crypto/dsprot.rs
+++ b/lib/src/crypto/dsprot.rs
@@ -19,37 +19,37 @@ const DSPROT_VERSIONS: &[DsProtVersion] = &[
     DsProtVersion {
         number: "1.00/2",
         detect_signature: [0xe3527270, 0xbafe77fc, 0xe59e0989, 0xe1c2f9af, 0xea018a51, 0xeb004ae2],
-        algo: &DsProtAlgoV1,
+        algo: &DsProtAlgoV1 { encrypted_range_start_signature: [0xe92d0001, 0xe1a0000f, 0xe2800010, 0xe8bd0001, 0xea000000] },
     },
     DsProtVersion {
         number: "1.05",
         detect_signature: [0xbafe0f18, 0xe59caf7a, 0xe2861884, 0xe1c5da54, 0xea018a6b, 0xeb0070c2],
-        algo: &DsProtAlgoV1,
+        algo: &DsProtAlgoV1 { encrypted_range_start_signature: [0xe92d0001, 0xe3a0000c, 0xe080000f, 0xe8bd0001, 0xea000000] },
     },
     DsProtVersion {
         number: "1.06",
         detect_signature: [0xbafe9b10, 0xe59cfa77, 0xe2862a71, 0xe1c54e3d, 0xea01879d, 0xeb005fdf],
-        algo: &DsProtAlgoV1,
+        algo: &DsProtAlgoV1 { encrypted_range_start_signature: [0xe92d000f, 0xe3a0100c, 0xe081000f, 0xe8bd000f, 0xea000000] },
     },
     DsProtVersion {
         number: "1.08",
         detect_signature: [0xbafe4040, 0xe59c2300, 0xe2852226, 0xe1c5cbe8, 0xea01612f, 0xeb004979],
-        algo: &DsProtAlgoV1,
+        algo: &DsProtAlgoV1 { encrypted_range_start_signature: [0xe92d00ff, 0xe1a0000f, 0xe2800010, 0xe8bd00ff, 0xea000000] },
     },
     DsProtVersion {
         number: "1.10",
         detect_signature: [0xbafe29a2, 0xe59cc95b, 0xe285d70a, 0xe1c5442c, 0xea01fd7e, 0xeb001cfc],
-        algo: &DsProtAlgoV1,
+        algo: &DsProtAlgoV1 { encrypted_range_start_signature: [0xe92d00ff, 0xe3a00006, 0xe08f0080, 0xe8bd00ff, 0xea000000] },
     },
     DsProtVersion {
         number: "1.20",
         detect_signature: [0xe3580f00, 0xbafe7df8, 0xe284dff9, 0xe1c2059d, 0xea014de4, 0xeb002f0c],
-        algo: &DsProtAlgoV1,
+        algo: &DsProtAlgoV1 { encrypted_range_start_signature: [0xe92d03ff, 0xe3a00006, 0xe08f0080, 0xe8bd03ff, 0xea000000] },
     },
     DsProtVersion {
         number: "1.22",
         detect_signature: [0xe3581567, 0xbafee339, 0xe284dad2, 0xe1c27622, 0xea017231, 0xeb0037ee],
-        algo: &DsProtAlgoV1,
+        algo: &DsProtAlgoV1 { encrypted_range_start_signature: [0xe92d03ff, 0xe3a00003, 0xe08f0100, 0xe8bd03ff, 0xea000000] },
     },
     DsProtVersion {
         number: "1.23",
@@ -69,57 +69,73 @@ const DSPROT_VERSIONS: &[DsProtVersion] = &[
     DsProtVersion {
         number: "1.26",
         detect_signature: [0xeb8fbc31, 0xe4ec10cf, 0xef73e592, 0xe59a0b7e, 0xe78cb309, 0xe87f3ed1],
-        algo: &DsProtAlgoV3 { reference_offset: 0x1200, unkeyed_encryption_xor: 0xf03852cb },
+        algo: &DsProtAlgoV4 { reference_offset: 0x1200, unkeyed_encryption_xor: 0xf03852cb },
     },
     DsProtVersion {
         number: "1.27",
         detect_signature: [0xe8dffe17, 0xe43df0de, 0x2ae8335c, 0x0ac09826, 0xe7a838dc, 0xe891a6fc],
-        algo: &DsProtAlgoV3 { reference_offset: 0x1600, unkeyed_encryption_xor: 0xf0618c46 },
+        algo: &DsProtAlgoV4 { reference_offset: 0x1600, unkeyed_encryption_xor: 0xf0618c46 },
     },
     DsProtVersion {
         number: "1.28",
         detect_signature: [0xe2ed720b, 0xef69d1b1, 0x2ec32a41, 0x1aa3e665, 0xe9e1c153, 0xe49e8d9c],
-        algo: &DsProtAlgoV3 { reference_offset: 0x1000, unkeyed_encryption_xor: 0xf0b9a2ea },
+        algo: &DsProtAlgoV4 { reference_offset: 0x1000, unkeyed_encryption_xor: 0xf0b9a2ea },
     },
     DsProtVersion {
         number: "2.00",
         detect_signature: [0x0819ff33, 0xe4a1ef1c, 0x5a85a2b3, 0xea0d2a0f, 0xe0d6bd78, 0xe29d9377],
-        algo: &DsProtAlgoV4 { reference_offset: 0x1700, unkeyed_encryption_xor: 0xa5ca49b3 },
+        algo: &DsProtAlgoV5 { reference_offset: 0x1700, unkeyed_encryption_xor: 0xa5ca49b3 },
     },
     DsProtVersion {
         number: "2.00 Instant",
         detect_signature: [0x0849ea8b, 0xe33b6243, 0x53b2d501, 0xe6847168, 0xebd886d7, 0xee3c09c0],
-        algo: &DsProtAlgoV4 { reference_offset: 0x1700, unkeyed_encryption_xor: 0xa5ca49b3 },
+        algo: &DsProtAlgoV5 { reference_offset: 0x1700, unkeyed_encryption_xor: 0xa5ca49b3 },
     },
     DsProtVersion {
         number: "2.01",
         detect_signature: [0x08d5310e, 0xe41bdb46, 0x5a3d9627, 0xeaf8fc79, 0xe016c9e7, 0xe2eb8130],
-        algo: &DsProtAlgoV4 { reference_offset: 0x2100, unkeyed_encryption_xor: 0x7fec9df1 },
+        algo: &DsProtAlgoV5 { reference_offset: 0x2100, unkeyed_encryption_xor: 0x7fec9df1 },
     },
     DsProtVersion {
         number: "2.01 Instant",
         detect_signature: [0x08637dd1, 0xe3618cb3, 0x5356f520, 0xe6b110ca, 0xeb4c1e5c, 0xeed91028],
-        algo: &DsProtAlgoV4 { reference_offset: 0x2100, unkeyed_encryption_xor: 0x7fec9df1 },
+        algo: &DsProtAlgoV5 { reference_offset: 0x2100, unkeyed_encryption_xor: 0x7fec9df1 },
     },
     DsProtVersion {
         number: "2.03",
         detect_signature: [0x08b76046, 0xe4177f2f, 0x5ab21c99, 0xea2af4b1, 0xe0fe885a, 0xe202fc9e],
-        algo: &DsProtAlgoV4 { reference_offset: 0x3200, unkeyed_encryption_xor: 0x7fec9df1 },
+        algo: &DsProtAlgoV6 {
+            reference_offset: 0x3200,
+            unkeyed_encryption_xor: 0x0976afcc,
+            precalculated_seed_key: 0xfa8fd0ea,
+        },
     },
     DsProtVersion {
         number: "2.03 Instant",
         detect_signature: [0x08b76046, 0xe4177f2f, 0x5ab21c99, 0xea2af4b1, 0xe0fe885a, 0xe2029efc],
-        algo: &DsProtAlgoV4 { reference_offset: 0x3200, unkeyed_encryption_xor: 0x7fec9df1 },
+        algo: &DsProtAlgoV6 {
+            reference_offset: 0x3200,
+            unkeyed_encryption_xor: 0x0976afcc,
+            precalculated_seed_key: 0xfa8fd0ea,
+        },
     },
     DsProtVersion {
         number: "2.05",
         detect_signature: [0x08a27510, 0xe47ab3c3, 0x5a289302, 0xeaa6cac8, 0xe00d75d5, 0xe2d2fe01],
-        algo: &DsProtAlgoV4 { reference_offset: 0x2200, unkeyed_encryption_xor: 0x7fec9df1 },
+        algo: &DsProtAlgoV6 {
+            reference_offset: 0x2200,
+            unkeyed_encryption_xor: 0x0a471abb,
+            precalculated_seed_key: 0x89ede4ea,
+        },
     },
     DsProtVersion {
         number: "2.05 Instant",
         detect_signature: [0x08a27510, 0xe47ab3c3, 0x5a289302, 0xeaa6cac8, 0xe00d75d5, 0xe2d2fe00],
-        algo: &DsProtAlgoV4 { reference_offset: 0x2200, unkeyed_encryption_xor: 0x7fec9df1 },
+        algo: &DsProtAlgoV6 {
+            reference_offset: 0x2200,
+            unkeyed_encryption_xor: 0x0a471abb,
+            precalculated_seed_key: 0x89ede4ea,
+        },
     },
 ];
 
@@ -166,6 +182,30 @@ pub enum DsProtError {
     /// Occurs when the DS Protect .bss variable address was not found.
     #[snafu(display("failed to find .bss variable address for DS Protect"))]
     BssNotFound {
+        /// Backtrace to the source of the error.
+        backtrace: Backtrace,
+    },
+    /// Occurs when failing to find the start of a function table decoder with children.
+    #[snafu(display("failed to find start of parent function table decoder near {near_address:#010x}"))]
+    TableDecoderStartNotFound {
+        /// The approximate location of the table decoder.
+        near_address: u32,
+        /// Backtrace to the source of the error.
+        backtrace: Backtrace,
+    },
+    /// Occurs when failing to find the end of a decoder's function table.
+    #[snafu(display("failed to find end of function table for decoder at {decoder_address:#010x}"))]
+    DecoderTableEndNotFound {
+        /// The address of the decoder function.
+        decoder_address: u32,
+        /// Backtrace to the source of the error.
+        backtrace: Backtrace,
+    },
+    /// Occurs when failing to find the instruction overwrite address for a primary decoder funciton.
+    #[snafu(display("failed to find the instruction overwrite address for primary decoder at {decoder_address:#010x}"))]
+    DecoderOverwriteAddressNotFound {
+        /// The address of the decoder function.
+        decoder_address: u32,
         /// Backtrace to the source of the error.
         backtrace: Backtrace,
     },
@@ -253,7 +293,8 @@ struct AlgoDecryptOptions {
 }
 
 const DECRYPTION_WRAPPER_SIGNATURE_1: [u32; 3] = [0xe92d00f0, 0xe92d000f, 0xe8bd00f0];
-const DECRYPTION_WRAPPER_SIGNATURE_2: [u32; 3] = [0xe18fc00f, 0xe01cc00c, 0x03a0c000];
+const DECRYPTION_WRAPPER_SIGNATURE_2: [u32; 4] = [0xe18fc00f, 0xe01cc00c, 0x03a0c000, 0x128cc01c];
+const DECRYPTION_WRAPPER_SIGNATURE_3: [u32; 4] = [0xe18fc00f, 0xe01cc00c, 0x03a0c000, 0x128cc068];
 
 trait DsProtAlgo {
     fn algorithm(&self) -> DsProtAlgoVersion;
@@ -262,40 +303,58 @@ trait DsProtAlgo {
     fn unkeyed_encryption_xor(&self) -> u32;
     fn unkeyed_encrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32);
     fn unkeyed_decrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32);
-    fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32) -> u32;
+    fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32, prev_ins: u32) -> u32;
+    fn precalculated_seed_key(&self) -> Option<u32>;
     fn init_rc4(&self, seed_key: u32, func_size: u32) -> Rc4;
 
     // The below default implementations are for version 1.23 onwards (DsProtAlgoV2, V3 and V4), as
+    // the de/encryption procedure for those versions are essentially identical aside from the bit
     // the de/encryption procedure for those versions are essentially identical aside from the bit
     // twiddling.
 
     fn decrypt(&self, words: &mut [u32], options: &AlgoDecryptOptions) -> Result<DsProtDecryptDetails, DsProtError> {
         let dsprot_bss = self.find_bss_variable(words, options)?;
-        let obfuscated_function_tables = find_obfuscated_function_tables(options, words)?;
+        let obfuscated_function_tables = self.find_obfuscated_function_tables(options, words)?;
         let mut unkeyed_encrypted_functions =
             self.decode_function_tables(options, words, dsprot_bss, &obfuscated_function_tables)?;
-        let mut keyed_encrypted_functions =
-            self.unkeyed_decrypt_functions(options, words, dsprot_bss, &unkeyed_encrypted_functions)?;
+        let (mut keyed_encrypted_functions, mut encoded_function_pointers) =
+            self.unkeyed_decrypt_functions(options, words, dsprot_bss, &mut unkeyed_encrypted_functions)?;
         self.decrypt_wrappers(options, words, &mut keyed_encrypted_functions)?;
+
+        encoded_function_pointers.sort_unstable_by_key(|fp| fp.0);
+        encoded_function_pointers.dedup();
+        self.decode_function_pointers(options, words, &encoded_function_pointers)?;
 
         let mut encrypted_functions = obfuscated_function_tables;
         encrypted_functions.append(&mut unkeyed_encrypted_functions);
         encrypted_functions.append(&mut keyed_encrypted_functions);
+        encrypted_functions.sort_unstable_by_key(|f| f.address);
 
-        Ok(DsProtDecryptDetails::Post1_23 { algorithm: self.algorithm(), dsprot_bss, encrypted_functions })
+        Ok(DsProtDecryptDetails::Post1_23 {
+            algorithm: self.algorithm(),
+            dsprot_bss,
+            encrypted_functions,
+            encoded_function_pointers,
+        })
     }
 
     fn find_bss_variable(&self, words: &[u32], options: &AlgoDecryptOptions) -> Result<u32, DsProtError> {
         let AlgoDecryptOptions { base_address, .. } = *options;
 
-        let signature_1 = self.unkeyed_encrypt_decryption_wrapper(DECRYPTION_WRAPPER_SIGNATURE_1);
-        let signature_2 = self.unkeyed_encrypt_decryption_wrapper(DECRYPTION_WRAPPER_SIGNATURE_2);
+        let mut signature_1 = DECRYPTION_WRAPPER_SIGNATURE_1;
+        let mut signature_2 = DECRYPTION_WRAPPER_SIGNATURE_2;
+        let mut signature_3 = DECRYPTION_WRAPPER_SIGNATURE_3;
+        let signature_1 = self.unkeyed_encrypt_decryption_wrapper(&mut signature_1);
+        let signature_2 = self.unkeyed_encrypt_decryption_wrapper(&mut signature_2);
+        let signature_3 = self.unkeyed_encrypt_decryption_wrapper(&mut signature_3);
 
-        for (i, window) in words.windows(3).enumerate() {
-            let func_size = if window == signature_1 {
+        for (i, window) in words.windows(4).enumerate() {
+            let func_size = if &window[0..3] == signature_1 {
                 0x68
             } else if window == signature_2 {
                 0x24
+            } else if window == signature_3 {
+                0x70
             } else {
                 continue;
             };
@@ -316,15 +375,115 @@ trait DsProtAlgo {
         BssNotFoundSnafu.fail()
     }
 
-    fn unkeyed_encrypt_decryption_wrapper(&self, signature: [u32; 3]) -> [u32; 3] {
-        let mut encrypted_signature = [0u32; 3];
+    fn unkeyed_encrypt_decryption_wrapper<'a>(&self, signature: &'a mut [u32]) -> &'a [u32] {
         let mut xor = self.unkeyed_encryption_xor();
-        for (i, ins) in signature.iter().enumerate() {
+        for ins in signature.iter_mut() {
             let (new_ins, new_xor) = self.unkeyed_encrypt_instruction(*ins, xor);
-            encrypted_signature[i] = new_ins;
+            *ins = new_ins;
             xor = new_xor;
         }
-        encrypted_signature
+        signature
+    }
+
+    fn find_obfuscated_function_tables(
+        &self,
+        options: &AlgoDecryptOptions,
+        words: &mut [u32],
+    ) -> Result<Vec<EncryptedFunction>, DsProtError> {
+        let AlgoDecryptOptions { base_address, .. } = *options;
+
+        let mut encrypted_functions = Vec::new();
+        for (i, window) in words.windows(4).enumerate() {
+            let address = base_address + i as u32 * 4;
+            let (pool_offset, fn_offset, primary_decoder) =
+                if window[0..2] == [0xe38f0000, 0xe2900004] && window[2] >> 24 == 0x1a {
+                    let (fn_offset, primary_decoder) = if words[i - 1] == 0xe8a007fe {
+                        let fn_offset = words[..=i]
+                            .iter()
+                            .rev()
+                            .position(|&word| word == 0xe92d4000)
+                            .ok_or_else(|| TableDecoderStartNotFoundSnafu { near_address: address }.build())?
+                            as u32;
+                        (fn_offset * 4, true)
+                    } else {
+                        (0, false)
+                    };
+                    (0xc, fn_offset, primary_decoder)
+                } else if window[0..2] == [0xe92d4000, 0xe28f0004] && window[2] >> 24 == 0xeb && window[3] == 0xe8bd8000 {
+                    (0x10, 0, false)
+                } else {
+                    continue;
+                };
+
+            let pool_address = address + pool_offset;
+            let pool_position = (pool_address - base_address) as usize / 4;
+            let mut pool_iter = words[pool_position..].iter().copied().enumerate();
+            let table_end_address = loop {
+                let Some((i, word)) = pool_iter.next() else {
+                    return DecoderTableEndNotFoundSnafu { decoder_address: address - fn_offset }.fail();
+                };
+                if word == 0
+                    && let Some((_, 0)) = pool_iter.next()
+                {
+                    break pool_address + i as u32 * 4 + 8;
+                }
+            };
+
+            // Get up to 2 trailing addresses after the decoded function table
+            let trailing_address_1 =
+                words.get((table_end_address - base_address) as usize / 4).copied().filter(|&addr| addr >> 24 == 0x02);
+            let trailing_address_2 = if trailing_address_1.is_some() {
+                words.get((table_end_address + 4 - base_address) as usize / 4).copied().filter(|&addr| addr >> 24 == 0x02)
+            } else {
+                None
+            };
+
+            let (garbage_address, overwrite_address) = match (primary_decoder, trailing_address_1, trailing_address_2) {
+                // No trailing addresses
+                (_, None, None) => (None, None),
+                // Second trailing address is always None if first trailing address is None
+                (_, None, Some(_)) => unreachable!(),
+                // Not primary but has a garbage address
+                (false, Some(garbage_address), _) => {
+                    if garbage_address - self.reference_offset() > address {
+                        // Points to .data which is always after .text
+                        (Some(garbage_address), None)
+                    } else {
+                        // Points to .text, so this must be a different unrelated pointer
+                        (None, None)
+                    }
+                }
+                // Primary without garbage address
+                (true, Some(overwrite_address), None) => (None, Some(overwrite_address)),
+                // Primary with garbage address
+                (true, Some(garbage_address), Some(overwrite_address)) => {
+                    if garbage_address - self.reference_offset() > address {
+                        // Points to .data which is always after .text
+                        (Some(garbage_address), Some(overwrite_address))
+                    } else {
+                        // Points to .text, so this must be a different unrelated pointer
+                        (None, None)
+                    }
+                }
+            };
+
+            // Primary decoder always overwrites itself after it runs
+            if primary_decoder && overwrite_address.is_none() {
+                return DecoderOverwriteAddressNotFoundSnafu { decoder_address: address - fn_offset }.fail();
+            }
+
+            encrypted_functions.push(EncryptedFunction {
+                address: address - fn_offset,
+                size: pool_offset + fn_offset,
+                encryption: EncryptionType::None,
+                constant_pool: EncodedConstantPool::ObfuscatedFunctionTable {
+                    with_garbage: garbage_address.is_some(),
+                    with_overwrite: overwrite_address.is_some(),
+                },
+            });
+        }
+
+        Ok(encrypted_functions)
     }
 
     fn unkeyed_decrypt_functions(
@@ -332,24 +491,23 @@ trait DsProtAlgo {
         options: &AlgoDecryptOptions,
         words: &mut [u32],
         dsprot_bss: u32,
-        unkeyed_encrypted_functions: &[EncryptedFunction],
-    ) -> Result<Vec<EncryptedFunction>, DsProtError> {
+        unkeyed_encrypted_functions: &mut [EncryptedFunction],
+    ) -> Result<(Vec<EncryptedFunction>, Vec<EncodedFunctionPointer>), DsProtError> {
         let AlgoDecryptOptions { base_address, end_address, .. } = *options;
 
         let mut decryption_wrappers = Vec::new();
-        for &EncryptedFunction { address: func_address, size: func_size, encryption, constant_pool: _ } in
-            unkeyed_encrypted_functions
-        {
-            let EncryptionType::Unkeyed = encryption else { continue };
+        let mut encoded_function_pointers = Vec::new();
+        for function in unkeyed_encrypted_functions {
+            let EncryptionType::Unkeyed = function.encryption else { continue };
 
-            let func_offset = ((func_address - base_address) / 4) as usize;
-            let instruction_count = (func_size / 4) as usize;
+            let func_offset = ((function.address - base_address) / 4) as usize;
+            let instruction_count = (function.size / 4) as usize;
 
             let Some(func_words) = words.get_mut(func_offset..func_offset + instruction_count) else {
                 return RangeOutOfBoundsSnafu {
                     what: "unkeyed encrypted function",
-                    start: func_address,
-                    end: func_address + func_size,
+                    start: function.address,
+                    end: function.address + function.size,
                     base_address,
                     end_address,
                 }
@@ -358,7 +516,7 @@ trait DsProtAlgo {
 
             let mut xor_value = self.unkeyed_encryption_xor();
 
-            log::debug!("Decrypting function at {:#010x} with size {:#x}", func_address, func_size);
+            log::debug!("Decrypting function at {:#010x} with size {:#x}", function.address, function.size);
 
             for instruction in func_words.iter_mut() {
                 let (new_instruction, new_xor_value) = self.unkeyed_decrypt_instruction(*instruction, xor_value);
@@ -369,32 +527,39 @@ trait DsProtAlgo {
             let reference_offset = self.reference_offset();
 
             if func_words.len() >= 3 && func_words[0..3] == DECRYPTION_WRAPPER_SIGNATURE_1 {
-                let pool_words = get_constant_pool(base_address, end_address, words, func_address, func_size, 4)?;
+                let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 5)?;
 
                 let bss = pool_words[0] - 1;
                 debug_assert_eq!(bss, dsprot_bss);
                 let dest_func_size = pool_words[1] - dsprot_bss - reference_offset;
                 let seed_key = pool_words[2] - dsprot_bss - reference_offset;
                 let dest_func_address = pool_words[3] - reference_offset;
+                let garbage_address = pool_words[4] - reference_offset;
 
                 pool_words[0] = bss;
                 pool_words[1] = dest_func_size;
                 pool_words[2] = seed_key;
                 pool_words[3] = dest_func_address;
+                let with_garbage = garbage_address >> 24 == 0x02;
+                if with_garbage {
+                    // sanity check that this looks like a RAM address
+                    pool_words[4] = garbage_address;
+                }
 
+                function.constant_pool = EncodedConstantPool::DecryptionWrapperType1 { with_garbage };
                 log::debug!(
                     "Found decryption wrapper (type 1) at {:#010x} which targets {:#010x}",
-                    func_address,
+                    function.address,
                     dest_func_address
                 );
                 decryption_wrappers.push(EncryptedFunction {
                     address: dest_func_address,
                     size: dest_func_size,
                     encryption: EncryptionType::Keyed(seed_key),
-                    constant_pool: EncodedConstantPool::DecryptionWrapperType1,
+                    constant_pool: EncodedConstantPool::None,
                 });
-            } else if func_words.len() >= 3 && func_words[0..3] == DECRYPTION_WRAPPER_SIGNATURE_2 {
-                let pool_words = get_constant_pool(base_address, end_address, words, func_address, func_size, 6)?;
+            } else if func_words.len() >= 4 && func_words[0..4] == DECRYPTION_WRAPPER_SIGNATURE_2 {
+                let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 7)?;
 
                 let bss = pool_words[0] - 1;
                 debug_assert_eq!(bss, dsprot_bss);
@@ -402,27 +567,135 @@ trait DsProtAlgo {
                 let dest_func_address = pool_words[2] - reference_offset;
                 let dest_func_size = pool_words[3] - dsprot_bss - reference_offset;
                 let wrapper_fragment = pool_words[5] - reference_offset;
+                let garbage_address = pool_words[6] - reference_offset;
 
                 pool_words[0] = bss;
                 pool_words[1] = seed_key;
                 pool_words[2] = dest_func_address;
                 pool_words[3] = dest_func_size;
                 pool_words[5] = wrapper_fragment;
+                let with_garbage = garbage_address >> 24 == 0x02;
+                if with_garbage {
+                    // sanity check that this looks like a RAM address
+                    pool_words[6] = garbage_address;
+                }
 
+                function.constant_pool = EncodedConstantPool::DecryptionWrapperType2 { with_garbage };
                 log::debug!(
                     "Found decryption wrapper (type 2) at {:#010x} which targets {:#010x}",
-                    func_address,
+                    function.address,
                     dest_func_address
                 );
                 decryption_wrappers.push(EncryptedFunction {
                     address: dest_func_address,
                     size: dest_func_size,
                     encryption: EncryptionType::Keyed(seed_key),
-                    constant_pool: EncodedConstantPool::DecryptionWrapperType2,
+                    constant_pool: EncodedConstantPool::None,
                 });
+            } else if func_words.len() >= 4 && func_words[0..4] == DECRYPTION_WRAPPER_SIGNATURE_3 {
+                let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 7)?;
+
+                let bss = pool_words[0] - 1;
+                debug_assert_eq!(bss, dsprot_bss);
+                let seed_key_placeholder = pool_words[1] - 3;
+                let dest_func_address = pool_words[2] - reference_offset;
+                let dest_func_size = pool_words[3] - dsprot_bss - reference_offset;
+                let wrapper_fragment = pool_words[5] & 0x03ffffff;
+                let garbage_address = pool_words[6] - reference_offset;
+
+                let wrapper_fragment_size = pool_words[5] >> 26;
+
+                pool_words[0] = bss;
+                pool_words[1] = seed_key_placeholder;
+                pool_words[2] = dest_func_address;
+                pool_words[3] = dest_func_size;
+                pool_words[5] = wrapper_fragment;
+                let with_garbage = garbage_address >> 24 == 0x02;
+                if with_garbage {
+                    // sanity check that this looks like a RAM address
+                    pool_words[6] = garbage_address;
+                }
+
+                // let wrapper_fragment_offset = ((wrapper_fragment - base_address) / 4) as usize;
+                // let Some(wrapper_fragment_words) =
+                //     words.get(wrapper_fragment_offset..wrapper_fragment_offset + wrapper_fragment_size as usize)
+                // else {
+                //     return RangeOutOfBoundsSnafu {
+                //         what: "wrapper fragment",
+                //         start: wrapper_fragment,
+                //         end: wrapper_fragment + wrapper_fragment_size * 4,
+                //         base_address,
+                //         end_address,
+                //     }
+                //     .fail();
+                // };
+
+                // let mut seed_key = 0;
+                // for &word in wrapper_fragment_words {
+                //     println!("WORD {:#010x}", word);
+                //     let opcode = word >> 24;
+                //     if opcode == 0xea || opcode == 0xeb {
+                //         // skip branch instructions
+                //         continue;
+                //     }
+                //     seed_key ^= word.rotate_right(17);
+                //     seed_key = seed_key.wrapping_add(word.rotate_right(28));
+                //     seed_key ^= word.rotate_right(1);
+                // }
+
+                let seed_key = self.precalculated_seed_key().unwrap();
+
+                function.constant_pool = EncodedConstantPool::DecryptionWrapperType3 { with_garbage };
+                log::debug!(
+                    "Found decryption wrapper (type 3) at {:#010x} which targets {:#010x}. \
+                    Seed key {:#010x} was derived from function at {:#010x} with size {:#x}",
+                    function.address,
+                    dest_func_address,
+                    seed_key,
+                    wrapper_fragment,
+                    wrapper_fragment_size * 4,
+                );
+                decryption_wrappers.push(EncryptedFunction {
+                    address: dest_func_address,
+                    size: dest_func_size,
+                    encryption: EncryptionType::Keyed(seed_key),
+                    constant_pool: EncodedConstantPool::None,
+                });
+            } else if func_words[0..4] == [0xe92d4070, 0xe24dd010, 0xe59f40ac, 0xe59fc0ac] {
+                // Decryption proxy
+                let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 2)?;
+                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[1]));
+                log::debug!("Decrypted decryption proxy function");
+            } else if func_words[0..4] == [0xe92d41f0, 0xe24dd010, 0xe1a05000, 0xe59f00c0] {
+                // Encryption proxy
+                let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 1)?;
+                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[0]));
+                log::debug!("Decrypted encryption proxy function");
+            } else if func_words[0..4] == [0xe92d000f, 0xe58ca010, 0xe1a0a00c, 0xe59fc054] {
+                // Decryption wrapper proxy
+                let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 2)?;
+                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[0]));
+                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[1]));
+                log::debug!("Decrypted decryption wrapper proxy function");
+            } else if func_words[0..4] == [0xe92d4ff8, 0xe24dd008, 0xe1a0b003, 0xe1a0a000]
+                || func_words[0..4] == [0xe92d4ff8, 0xe24dd010, 0xe1a0a000, 0xe1a00003]
+            {
+                // RC4 encryptor/decryptor
+                let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 1)?;
+                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[0]));
+                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[0] + 0xc));
+                log::debug!("Found RC4 encryptor/decryptor");
+            } else if func_words[0..4] == [0xe92d43f0, 0xe24ddf43, 0xe59f7064, 0xe28d8000] {
+                // RC4 encrypt/decrypt function
+                let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 1)?;
+                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[0]));
+                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[0] + 0x4));
+                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[0] + 0x8));
+                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[0] + 0x10));
+                log::debug!("Found RC4 encrypt/decrypt function");
             }
         }
-        Ok(decryption_wrappers)
+        Ok((decryption_wrappers, encoded_function_pointers))
     }
 
     fn decode_function_tables(
@@ -435,9 +708,13 @@ trait DsProtAlgo {
         let AlgoDecryptOptions { base_address, end_address, .. } = *options;
 
         let mut encrypted_functions = Vec::new();
-        for &EncryptedFunction { address: func_address, size: func_size, encryption: _, constant_pool: _ } in
+        for &EncryptedFunction { address: func_address, size: func_size, encryption: _, constant_pool } in
             obfuscated_function_tables
         {
+            let EncodedConstantPool::ObfuscatedFunctionTable { with_garbage, with_overwrite } = constant_pool else {
+                continue;
+            };
+
             let function_table_address = func_address + func_size;
 
             log::debug!("Obfuscated function table found at {:#010x}", function_table_address);
@@ -453,7 +730,8 @@ trait DsProtAlgo {
                 .fail();
             };
 
-            for chunk in pool_words.chunks_exact_mut(2) {
+            let mut chunk_iter = pool_words.chunks_exact_mut(2);
+            for chunk in chunk_iter.by_ref() {
                 if chunk[0] == 0 {
                     // End of list
                     break;
@@ -472,6 +750,17 @@ trait DsProtAlgo {
                     encryption: EncryptionType::Unkeyed,
                     constant_pool: EncodedConstantPool::None,
                 });
+            }
+
+            // Decode pointer to garbage data
+            if with_garbage && let Some(next_chunk) = chunk_iter.next() {
+                next_chunk[0] -= self.reference_offset();
+                log::debug!("Decoded garbage pointer after decoder function at {:#010x}", func_address);
+            }
+            // Decode pointer to this decoder function
+            if with_overwrite && let Some(next_chunk) = chunk_iter.next() {
+                next_chunk[0] -= self.reference_offset();
+                log::debug!("Decoded overwrite pointer after decoder function at {:#010x}", func_address);
             }
         }
         Ok(encrypted_functions)
@@ -512,8 +801,16 @@ trait DsProtAlgo {
                 }
                 .fail();
             };
-            for instruction in func_words.iter_mut() {
-                *instruction = self.decrypt_instruction(&mut rc4, *instruction);
+            let mut prev_ins = 0;
+            for (i, instruction) in func_words.iter_mut().enumerate() {
+                let ins = *instruction;
+                *instruction = self.decrypt_instruction(&mut rc4, ins, prev_ins);
+                prev_ins = ins;
+
+                let options = unarm::Options::default();
+                let pc = function.address + i as u32 * 4;
+                let ins = unarm::parse_arm(*instruction, pc, &options);
+                println!("{:08x}  {:08x}  {}", pc, *instruction, ins.display(&options));
             }
 
             // Decrypt constant pools based on function signature
@@ -534,6 +831,8 @@ trait DsProtAlgo {
             let reference_offset = self.reference_offset();
 
             if func_start[0..4] == [0xe92d4ff8, 0xe24dd080, 0xe59f209c, 0xe59f109c]
+                || func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f3080, 0xe59f2080]
+                || func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f308c, 0xe59f208c]
                 || func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f307c, 0xe59f207c]
             {
                 // Flashcart/Emulator detector
@@ -543,7 +842,9 @@ trait DsProtAlgo {
                 pool_words[1] = integrity_fn_addr;
                 function.constant_pool = EncodedConstantPool::FlashcartEmulatorDetectorType1;
                 log::debug!("Decrypted flashcart/emulator detector (type 1)");
-            } else if func_start[0..4] == [0xe92d4ff8, 0xe24dd098, 0xe59f2170, 0xe59f4170] {
+            } else if func_start[0..4] == [0xe92d4ff8, 0xe24dd098, 0xe59f2170, 0xe59f4170]
+                || func_start[0..4] == [0xe92d4ff8, 0xe24dd098, 0xe59f2174, 0xe59f4174]
+            {
                 // Flashcart/Emulator detector
                 let callback_index_addr = pool_words[0] - reference_offset;
                 let callback_table_addr = pool_words[1] - reference_offset;
@@ -555,50 +856,68 @@ trait DsProtAlgo {
                 pool_words[3] = integrity_fn_addr;
                 function.constant_pool = EncodedConstantPool::FlashcartEmulatorDetectorType2;
                 log::debug!("Decrypted flashcart/emulator detector (type 2)");
-            } else if func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f3070, 0xe3a02000] {
+            } else if func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f3070, 0xe3a02000]
+                || func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f3074, 0xe3a02000]
+                || func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f3080, 0xe3a02000]
+            {
                 // Dummy detector
                 let test_fn_addr = pool_words[0] - reference_offset;
                 pool_words[0] = test_fn_addr;
                 function.constant_pool = EncodedConstantPool::DummyDetector;
                 log::debug!("Decrypted dummy detector");
+            } else if func_start[0..4] == [0xe92d4ff8, 0xe94dd018, 0xe59fa100, 0xe59f6100] {
+                // MAC and ROM integrity checkers
+                let mac_integrity_fn_addr = pool_words[0] - reference_offset;
+                let mac_test_fn_addr = pool_words[1] - reference_offset;
+                let rom_integrity_fn_addr = pool_words[2] - reference_offset;
+                let rom_test_fn_addr = pool_words[3] - reference_offset;
+                pool_words[0] = mac_integrity_fn_addr;
+                pool_words[1] = mac_test_fn_addr;
+                pool_words[2] = rom_integrity_fn_addr;
+                pool_words[3] = rom_test_fn_addr;
+                function.constant_pool = EncodedConstantPool::MacRomIntegrityChecker;
+                log::debug!("Decrypted MAC and ROM integrity checkers");
             } else if func_start[6] == 0x112fff1e {
                 // Integrity checkers
                 let checked_fn_addr = pool_words[0] - self.integrity_check_offset();
                 pool_words[0] = checked_fn_addr;
                 function.constant_pool = EncodedConstantPool::IntegrityChecker;
                 log::debug!("Decrypted integrity checker");
+            } else if func_start[0..4] == [0xe1a0a00f, 0xe19aa00a, 0x102ee00e, 0xe25aa008] {
+                // Crash
+                let clear_fn_addr = pool_words[0] - reference_offset;
+                let terminate_fn_addr = pool_words[1] - reference_offset;
+                pool_words[0] = clear_fn_addr;
+                pool_words[1] = terminate_fn_addr;
+                function.constant_pool = EncodedConstantPool::Crash;
+                log::debug!("Decrypted crash function");
             }
             // The other function types don't have any encrypted constant pools
         }
         Ok(())
     }
-}
 
-fn find_obfuscated_function_tables(
-    options: &AlgoDecryptOptions,
-    words: &mut [u32],
-) -> Result<Vec<EncryptedFunction>, DsProtError> {
-    let AlgoDecryptOptions { base_address, .. } = *options;
-
-    let mut encrypted_functions = Vec::new();
-    for (i, window) in words.windows(4).enumerate() {
-        let address = base_address + i as u32 * 4;
-        let pool_offset = if window[0..2] == [0xe38f0000, 0xe2900004] && window[2] >> 24 == 0x1a {
-            0xc
-        } else if window[0..2] == [0xe92d4000, 0xe28f0004] && window[2] >> 24 == 0xeb && window[3] == 0xe8bd8000 {
-            0x10
-        } else {
-            continue;
-        };
-        encrypted_functions.push(EncryptedFunction {
-            address,
-            size: pool_offset,
-            encryption: EncryptionType::None,
-            constant_pool: EncodedConstantPool::ObfuscatedFunctionTable,
-        });
+    fn decode_function_pointers(
+        &self,
+        options: &AlgoDecryptOptions,
+        words: &mut [u32],
+        encoded_function_pointers: &[EncodedFunctionPointer],
+    ) -> Result<(), DsProtError> {
+        let &AlgoDecryptOptions { base_address, end_address } = options;
+        for &encoded_fn_ptr in encoded_function_pointers.iter() {
+            let Some(encoded_fn) = words.get_mut((encoded_fn_ptr.0 - base_address) as usize / 4) else {
+                return OutOfBoundsSnafu {
+                    what: "encoded function pointer",
+                    address: encoded_fn_ptr.0,
+                    base_address,
+                    end_address,
+                }
+                .fail();
+            };
+            *encoded_fn -= self.reference_offset();
+        }
+        Ok(())
     }
-
-    Ok(encrypted_functions)
 }
 
 fn get_constant_pool(
@@ -693,15 +1012,21 @@ pub enum DsProtAlgoVersion {
     V1(DsProtAlgoV1),
     /// Before 1.25
     V2(DsProtAlgoV2),
-    /// Before 2.00
+    /// 1.25 only
     V3(DsProtAlgoV3),
-    /// 2.00 onwards
+    /// Before 2.00
     V4(DsProtAlgoV4),
+    /// Before 2.03
+    V5(DsProtAlgoV5),
+    /// 2.03 onwards
+    V6(DsProtAlgoV6),
 }
 
 /// Before 1.23
 #[derive(Clone, Copy, Serialize, Deserialize)]
-pub struct DsProtAlgoV1;
+pub struct DsProtAlgoV1 {
+    encrypted_range_start_signature: [u32; 5],
+}
 
 /// Before 1.25
 #[derive(Clone, Copy, Serialize, Deserialize)]
@@ -710,18 +1035,33 @@ pub struct DsProtAlgoV2 {
     unkeyed_encryption_xor: u32,
 }
 
-/// Before 2.00
+/// 1.25 only
 #[derive(Clone, Copy, Serialize, Deserialize)]
 pub struct DsProtAlgoV3 {
     reference_offset: u32,
     unkeyed_encryption_xor: u32,
 }
 
-/// 2.00 onwards
+/// Before 2.00
 #[derive(Clone, Copy, Serialize, Deserialize)]
 pub struct DsProtAlgoV4 {
     reference_offset: u32,
     unkeyed_encryption_xor: u32,
+}
+
+/// Before 2.03
+#[derive(Clone, Copy, Serialize, Deserialize)]
+pub struct DsProtAlgoV5 {
+    reference_offset: u32,
+    unkeyed_encryption_xor: u32,
+}
+
+/// 2.03 onwards
+#[derive(Clone, Copy, Serialize, Deserialize)]
+pub struct DsProtAlgoV6 {
+    reference_offset: u32,
+    unkeyed_encryption_xor: u32,
+    precalculated_seed_key: u32,
 }
 
 impl DsProtAlgo for DsProtAlgoV1 {
@@ -749,9 +1089,13 @@ impl DsProtAlgo for DsProtAlgoV1 {
         (ins, xor) // unused
     }
 
-    fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32) -> u32 {
+    fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32, _prev_ins: u32) -> u32 {
         let bytes = ins.to_le_bytes();
         u32::from_le_bytes([rc4.decrypt_byte(bytes[0]), rc4.decrypt_byte(bytes[1]), bytes[2] ^ 0x01, bytes[3]])
+    }
+
+    fn precalculated_seed_key(&self) -> Option<u32> {
+        None
     }
 
     fn init_rc4(&self, seed_key: u32, _func_size: u32) -> Rc4 {
@@ -766,13 +1110,7 @@ impl DsProtAlgo for DsProtAlgoV1 {
         let encrypted_range_starts: Vec<(u32, u32)> = words
             .windows(7)
             .enumerate()
-            .filter(|(_i, word)| {
-                word[0] == 0xe92d03ff
-                    && word[1] == 0xe3a00006
-                    && word[2] == 0xe08f0080
-                    && word[4] == 0xe8bd03ff
-                    && word[5] == 0xea000000
-            })
+            .filter(|(_i, word)| [word[0], word[1], word[2], word[4], word[5]] == self.encrypted_range_start_signature)
             .map(|(i, word)| {
                 let start_address = base_address + i as u32 * 4 + 0x1c;
                 let key = word[6];
@@ -793,9 +1131,11 @@ impl DsProtAlgo for DsProtAlgoV1 {
                     encrypted_ranges.push(EncryptedRange { start_address, end_address: address });
                     break;
                 }
-                words[offset] = self.decrypt_instruction(&mut rc4, instruction);
+                let prev_ins = 0; // unused
+                words[offset] = self.decrypt_instruction(&mut rc4, instruction, prev_ins);
             }
         }
+        encrypted_ranges.sort_unstable_by_key(|r| r.start_address);
 
         Ok(DsProtDecryptDetails::Pre1_23 { encrypted_ranges })
     }
@@ -836,7 +1176,7 @@ impl DsProtAlgo for DsProtAlgoV2 {
         (new_ins, xor)
     }
 
-    fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32) -> u32 {
+    fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32, _prev_ins: u32) -> u32 {
         match InstructionCategory::new(ins) {
             InstructionCategory::BlxImm | InstructionCategory::Bl => decrypt_branch_1(self.reference_offset, ins),
             InstructionCategory::B => decrypt_branch_2(self.reference_offset, ins),
@@ -845,6 +1185,10 @@ impl DsProtAlgo for DsProtAlgoV2 {
                 u32::from_le_bytes([rc4.decrypt_byte(bytes[0]), rc4.decrypt_byte(bytes[1]), bytes[2] ^ 1, bytes[3]])
             }
         }
+    }
+
+    fn precalculated_seed_key(&self) -> Option<u32> {
+        None
     }
 
     fn init_rc4(&self, seed_key: u32, func_size: u32) -> Rc4 {
@@ -856,6 +1200,86 @@ impl DsProtAlgo for DsProtAlgoV2 {
 impl DsProtAlgo for DsProtAlgoV3 {
     fn algorithm(&self) -> DsProtAlgoVersion {
         DsProtAlgoVersion::V3(*self)
+    }
+
+    fn reference_offset(&self) -> u32 {
+        self.reference_offset
+    }
+
+    fn integrity_check_offset(&self) -> u32 {
+        self.reference_offset * 2
+    }
+
+    fn unkeyed_encryption_xor(&self) -> u32 {
+        self.unkeyed_encryption_xor
+    }
+
+    fn unkeyed_encrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32) {
+        match InstructionCategory::new(ins) {
+            InstructionCategory::BlxImm | InstructionCategory::B => {
+                let new_ins = decrypt_branch_2(self.reference_offset, ins);
+                (new_ins, xor)
+            }
+            InstructionCategory::Bl => {
+                let new_ins = ins ^ xor ^ 0x01000000; // flip link bit
+                (new_ins, (xor << 1).wrapping_add(ins) & 0xffffff)
+            }
+            InstructionCategory::Other => {
+                let new_ins = ins ^ xor;
+                (new_ins, (xor << 1).wrapping_add(ins) & 0xffffff)
+            }
+        }
+    }
+
+    fn unkeyed_decrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32) {
+        match InstructionCategory::new(ins) {
+            InstructionCategory::BlxImm | InstructionCategory::B => {
+                let new_ins = decrypt_branch_2(self.reference_offset, ins);
+                (new_ins, xor)
+            }
+            InstructionCategory::Bl => {
+                let new_ins = ins ^ xor ^ 0x01000000; // flip link bit
+                (new_ins, (xor << 1).wrapping_add(new_ins) & 0xffffff)
+            }
+            InstructionCategory::Other => {
+                let new_ins = ins ^ xor;
+                (new_ins, (xor << 1).wrapping_add(new_ins) & 0xffffff)
+            }
+        }
+    }
+
+    fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32, _prev_ins: u32) -> u32 {
+        match InstructionCategory::new(ins) {
+            InstructionCategory::BlxImm | InstructionCategory::B => decrypt_branch_2(self.reference_offset, ins),
+            category => {
+                let bytes = ins.to_le_bytes();
+                u32::from_le_bytes([
+                    rc4.decrypt_byte(bytes[0]),
+                    rc4.decrypt_byte(bytes[1]),
+                    bytes[2] ^ 0x3f,
+                    if category == InstructionCategory::Bl {
+                        bytes[3] ^ 0x01 // flip link bit
+                    } else {
+                        bytes[3]
+                    },
+                ])
+            }
+        }
+    }
+
+    fn precalculated_seed_key(&self) -> Option<u32> {
+        None
+    }
+
+    fn init_rc4(&self, seed_key: u32, func_size: u32) -> Rc4 {
+        let expanded_key = expand_seed_key(seed_key, func_size);
+        Rc4::new(bytemuck::cast_slice(&expanded_key), Some(0xaa))
+    }
+}
+
+impl DsProtAlgo for DsProtAlgoV4 {
+    fn algorithm(&self) -> DsProtAlgoVersion {
+        DsProtAlgoVersion::V4(*self)
     }
 
     fn reference_offset(&self) -> u32 {
@@ -904,7 +1328,7 @@ impl DsProtAlgo for DsProtAlgoV3 {
         }
     }
 
-    fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32) -> u32 {
+    fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32, _prev_ins: u32) -> u32 {
         match InstructionCategory::new(ins) {
             InstructionCategory::BlxImm | InstructionCategory::B => {
                 rc4.update_x(|x| x.wrapping_add((ins >> 24) as u8));
@@ -928,15 +1352,19 @@ impl DsProtAlgo for DsProtAlgoV3 {
         }
     }
 
+    fn precalculated_seed_key(&self) -> Option<u32> {
+        None
+    }
+
     fn init_rc4(&self, seed_key: u32, func_size: u32) -> Rc4 {
         let expanded_key = expand_seed_key(seed_key, func_size);
         Rc4::new(bytemuck::cast_slice(&expanded_key), Some(0xaa))
     }
 }
 
-impl DsProtAlgo for DsProtAlgoV4 {
+impl DsProtAlgo for DsProtAlgoV5 {
     fn algorithm(&self) -> DsProtAlgoVersion {
-        DsProtAlgoVersion::V4(*self)
+        DsProtAlgoVersion::V5(*self)
     }
 
     fn reference_offset(&self) -> u32 {
@@ -963,7 +1391,7 @@ impl DsProtAlgo for DsProtAlgoV4 {
         (new_ins, new_xor)
     }
 
-    fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32) -> u32 {
+    fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32, _prev_ins: u32) -> u32 {
         match InstructionCategory::new(ins) {
             InstructionCategory::BlxImm | InstructionCategory::B => {
                 rc4.update_x(|x| x.wrapping_add((ins >> 24) as u8));
@@ -987,14 +1415,80 @@ impl DsProtAlgo for DsProtAlgoV4 {
         }
     }
 
+    fn precalculated_seed_key(&self) -> Option<u32> {
+        None
+    }
+
     fn init_rc4(&self, seed_key: u32, func_size: u32) -> Rc4 {
         let expanded_key = expand_seed_key(seed_key, func_size);
         Rc4::new(bytemuck::cast_slice(&expanded_key), Some(0xaa))
     }
 }
 
-/// Contains complete information about how DS Protect's encrypted code was decrypted. This is used
-/// when building a ROM so the decrypted code can be re-encrypted so it matches the original ROM.
+impl DsProtAlgo for DsProtAlgoV6 {
+    fn algorithm(&self) -> DsProtAlgoVersion {
+        DsProtAlgoVersion::V6(*self)
+    }
+
+    fn reference_offset(&self) -> u32 {
+        self.reference_offset
+    }
+
+    fn integrity_check_offset(&self) -> u32 {
+        self.reference_offset
+    }
+
+    fn unkeyed_encryption_xor(&self) -> u32 {
+        self.unkeyed_encryption_xor
+    }
+
+    fn unkeyed_encrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32) {
+        let new_ins = ins ^ xor;
+        let new_xor = xor ^ ins.wrapping_sub(ins >> 8);
+        (new_ins, new_xor)
+    }
+
+    fn unkeyed_decrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32) {
+        let new_ins = ins ^ xor;
+        let new_xor = xor ^ new_ins.wrapping_sub(new_ins >> 8);
+        (new_ins, new_xor)
+    }
+
+    fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32, prev_ins: u32) -> u32 {
+        let opcode = (ins >> 24) as u8;
+        let ins = ins ^ (prev_ins & 0xff000000);
+        let category = InstructionCategory::new(ins);
+        let new_ins = match category {
+            InstructionCategory::BlxImm | InstructionCategory::B => decrypt_branch_2(self.reference_offset, ins),
+            InstructionCategory::Bl | InstructionCategory::Other => {
+                let bytes = ins.to_le_bytes();
+                u32::from_le_bytes([
+                    rc4.decrypt_byte(bytes[0]),
+                    rc4.decrypt_byte(bytes[1]),
+                    rc4.decrypt_byte(bytes[2]),
+                    bytes[3],
+                ])
+            }
+        };
+        rc4.update_x(|x| x.wrapping_sub(opcode));
+        match category {
+            // flip link bit
+            InstructionCategory::Bl | InstructionCategory::BlxImm => new_ins ^ 0x01000000,
+            InstructionCategory::B | InstructionCategory::Other => new_ins,
+        }
+    }
+
+    fn precalculated_seed_key(&self) -> Option<u32> {
+        Some(self.precalculated_seed_key)
+    }
+
+    fn init_rc4(&self, seed_key: u32, func_size: u32) -> Rc4 {
+        let expanded_key = expand_seed_key(seed_key, func_size);
+        Rc4::new(bytemuck::cast_slice(&expanded_key), Some(0xaa))
+    }
+}
+
+/// Contains complete information about how DS Protect's encrypted code was decrypted.
 #[derive(Serialize, Deserialize)]
 pub enum DsProtDecryptDetails {
     /// Before DS Protect version 1.23
@@ -1010,6 +1504,8 @@ pub enum DsProtDecryptDetails {
         dsprot_bss: u32,
         /// List of encrypted functions.
         encrypted_functions: Vec<EncryptedFunction>,
+        /// List of encoded function pointers.
+        encoded_function_pointers: Vec<EncodedFunctionPointer>,
     },
 }
 
@@ -1037,9 +1533,9 @@ impl Display for DisplayDsProtDecryptDetails<'_> {
                     writeln!(f, "{i}  {:#010x}..{:#010x}", range.start_address, range.end_address)?;
                 }
             }
-            DsProtDecryptDetails::Post1_23 { algorithm, dsprot_bss, encrypted_functions } => {
-                writeln!(f, "{i}BSS variable ......... : {:#010x}", dsprot_bss)?;
-                write!(f, "{i}Algorithm ............ : ")?;
+            DsProtDecryptDetails::Post1_23 { algorithm, dsprot_bss, encrypted_functions, encoded_function_pointers } => {
+                writeln!(f, "{i}BSS variable ............... : {:#010x}", dsprot_bss)?;
+                write!(f, "{i}Algorithm .................. : ")?;
                 match algorithm {
                     DsProtAlgoVersion::V1(_algo) => {
                         writeln!(f, "v1")?;
@@ -1065,8 +1561,22 @@ impl Display for DisplayDsProtDecryptDetails<'_> {
                             algo.reference_offset, algo.unkeyed_encryption_xor
                         )?;
                     }
+                    DsProtAlgoVersion::V5(algo) => {
+                        writeln!(
+                            f,
+                            "v5 (reference offset = {:#x}, xor = {:#x})",
+                            algo.reference_offset, algo.unkeyed_encryption_xor
+                        )?;
+                    }
+                    DsProtAlgoVersion::V6(algo) => {
+                        writeln!(
+                            f,
+                            "v6 (reference offset = {:#x}, xor = {:#x}, seed_key = {:#x})",
+                            algo.reference_offset, algo.unkeyed_encryption_xor, algo.precalculated_seed_key
+                        )?;
+                    }
                 }
-                writeln!(f, "{i}Encrypted functions .. :")?;
+                writeln!(f, "{i}Encrypted functions ........ :")?;
                 for function in encrypted_functions {
                     writeln!(f, "{i}  Address ................ : {:#010x}", function.address)?;
                     writeln!(f, "{i}  Size ................... : {:#x}", function.size)?;
@@ -1083,6 +1593,10 @@ impl Display for DisplayDsProtDecryptDetails<'_> {
                         }
                     }
                     writeln!(f, "{i}  Encoded constant pool .. : {:?}\n", function.constant_pool)?;
+                }
+                writeln!(f, "{i}Encoded function pointers .. :")?;
+                for fn_ptr in encoded_function_pointers {
+                    writeln!(f, "{i}  Address .. : {:#010x}", fn_ptr.0)?;
                 }
             }
         }
@@ -1118,16 +1632,32 @@ pub enum EncryptionType {
 }
 
 /// Represents a type of DS Protect function whose constant pool contains encoded values.
-#[derive(Debug, Serialize, Deserialize)]
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
 pub enum EncodedConstantPool {
     /// No encoding, only encryption.
     None,
     /// Encodes an array of (function address, function size).
-    ObfuscatedFunctionTable,
-    /// Encodes BSS var address, dest function size, seed key, dest function address.
-    DecryptionWrapperType1,
+    ObfuscatedFunctionTable {
+        /// If true, a pointer to DS Protect's garbage data was appended to the end of the constant pool.
+        with_garbage: bool,
+        /// If true, a pointer to this decoder function was appended to the end of the constant pool.
+        with_overwrite: bool,
+    },
+    /// Encodes BSS var address, dest function size, seed key, dest function address, optionally pointer to garbage.
+    DecryptionWrapperType1 {
+        /// If true, a pointer to DS Protect's garbage data was appended to the end of the constant pool.
+        with_garbage: bool,
+    },
     /// Encodes BSS var address, seed key, dest function address, dest function size, wrapper fragment address.
-    DecryptionWrapperType2,
+    DecryptionWrapperType2 {
+        /// If true, a pointer to DS Protect's garbage data was appended to the end of the constant pool.
+        with_garbage: bool,
+    },
+    /// Encodes BSS var address, seed key placeholder, dest function address, dest function size, wrapper fragment address.
+    DecryptionWrapperType3 {
+        /// If true, a pointer to DS Protect's garbage data was appended to the end of the constant pool.
+        with_garbage: bool,
+    },
     /// Encodes test function address, integrity checker address.
     FlashcartEmulatorDetectorType1,
     /// Encodes callback index address, callback table address, test function address, integrity checker address.
@@ -1136,4 +1666,13 @@ pub enum EncodedConstantPool {
     DummyDetector,
     /// Encodes checked function address.
     IntegrityChecker,
+    /// Encodes two sets of checked function address, test function address.
+    MacRomIntegrityChecker,
+    /// Encodes memory clear function address, terminate function address.
+    Crash,
 }
+
+/// Represents a function pointer in a data section, which was encoded by adding the reference
+/// offset value.
+#[derive(PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+pub struct EncodedFunctionPointer(u32);

--- a/lib/src/crypto/dsprot.rs
+++ b/lib/src/crypto/dsprot.rs
@@ -1,0 +1,1139 @@
+// Credits to taxicat1 aka Mow:
+// https://github.com/taxicat1/dsprot
+// https://github.com/taxicat1/dsdetect
+
+use std::{backtrace::Backtrace, fmt::Display};
+
+use serde::{Deserialize, Serialize};
+use snafu::Snafu;
+
+use crate::crypto::rc4::Rc4;
+
+struct DsProtVersion {
+    number: &'static str,
+    detect_signature: [u32; 6],
+    algo: &'static dyn DsProtAlgo,
+}
+
+const DSPROT_VERSIONS: &[DsProtVersion] = &[
+    DsProtVersion {
+        number: "1.00/2",
+        detect_signature: [0xe3527270, 0xbafe77fc, 0xe59e0989, 0xe1c2f9af, 0xea018a51, 0xeb004ae2],
+        algo: &DsProtAlgoV1,
+    },
+    DsProtVersion {
+        number: "1.05",
+        detect_signature: [0xbafe0f18, 0xe59caf7a, 0xe2861884, 0xe1c5da54, 0xea018a6b, 0xeb0070c2],
+        algo: &DsProtAlgoV1,
+    },
+    DsProtVersion {
+        number: "1.06",
+        detect_signature: [0xbafe9b10, 0xe59cfa77, 0xe2862a71, 0xe1c54e3d, 0xea01879d, 0xeb005fdf],
+        algo: &DsProtAlgoV1,
+    },
+    DsProtVersion {
+        number: "1.08",
+        detect_signature: [0xbafe4040, 0xe59c2300, 0xe2852226, 0xe1c5cbe8, 0xea01612f, 0xeb004979],
+        algo: &DsProtAlgoV1,
+    },
+    DsProtVersion {
+        number: "1.10",
+        detect_signature: [0xbafe29a2, 0xe59cc95b, 0xe285d70a, 0xe1c5442c, 0xea01fd7e, 0xeb001cfc],
+        algo: &DsProtAlgoV1,
+    },
+    DsProtVersion {
+        number: "1.20",
+        detect_signature: [0xe3580f00, 0xbafe7df8, 0xe284dff9, 0xe1c2059d, 0xea014de4, 0xeb002f0c],
+        algo: &DsProtAlgoV1,
+    },
+    DsProtVersion {
+        number: "1.22",
+        detect_signature: [0xe3581567, 0xbafee339, 0xe284dad2, 0xe1c27622, 0xea017231, 0xeb0037ee],
+        algo: &DsProtAlgoV1,
+    },
+    DsProtVersion {
+        number: "1.23",
+        detect_signature: [0xebaa0113, 0xe4064ec7, 0xef013596, 0xe5212f83, 0xe7ee335b, 0xe83b197c],
+        algo: &DsProtAlgoV2 { reference_offset: 0x1300, unkeyed_encryption_xor: 0xf0566556 },
+    },
+    DsProtVersion {
+        number: "1.23z",
+        detect_signature: [0xebaa0114, 0x40064eb7, 0x5f013696, 0xe5211f83, 0xe7ef335b, 0xe84b197c],
+        algo: &DsProtAlgoV2 { reference_offset: 0x1400, unkeyed_encryption_xor: 0xd0685665 },
+    },
+    DsProtVersion {
+        number: "1.25",
+        detect_signature: [0xebb6df66, 0xe42f6211, 0xef56b5aa, 0xe5b903fd, 0xe7d29154, 0xe859697c],
+        algo: &DsProtAlgoV3 { reference_offset: 0x1500, unkeyed_encryption_xor: 0xf0556655 },
+    },
+    DsProtVersion {
+        number: "1.26",
+        detect_signature: [0xeb8fbc31, 0xe4ec10cf, 0xef73e592, 0xe59a0b7e, 0xe78cb309, 0xe87f3ed1],
+        algo: &DsProtAlgoV3 { reference_offset: 0x1200, unkeyed_encryption_xor: 0xf03852cb },
+    },
+    DsProtVersion {
+        number: "1.27",
+        detect_signature: [0xe8dffe17, 0xe43df0de, 0x2ae8335c, 0x0ac09826, 0xe7a838dc, 0xe891a6fc],
+        algo: &DsProtAlgoV3 { reference_offset: 0x1600, unkeyed_encryption_xor: 0xf0618c46 },
+    },
+    DsProtVersion {
+        number: "1.28",
+        detect_signature: [0xe2ed720b, 0xef69d1b1, 0x2ec32a41, 0x1aa3e665, 0xe9e1c153, 0xe49e8d9c],
+        algo: &DsProtAlgoV3 { reference_offset: 0x1000, unkeyed_encryption_xor: 0xf0b9a2ea },
+    },
+    DsProtVersion {
+        number: "2.00",
+        detect_signature: [0x0819ff33, 0xe4a1ef1c, 0x5a85a2b3, 0xea0d2a0f, 0xe0d6bd78, 0xe29d9377],
+        algo: &DsProtAlgoV4 { reference_offset: 0x1700, unkeyed_encryption_xor: 0xa5ca49b3 },
+    },
+    DsProtVersion {
+        number: "2.00 Instant",
+        detect_signature: [0x0849ea8b, 0xe33b6243, 0x53b2d501, 0xe6847168, 0xebd886d7, 0xee3c09c0],
+        algo: &DsProtAlgoV4 { reference_offset: 0x1700, unkeyed_encryption_xor: 0xa5ca49b3 },
+    },
+    DsProtVersion {
+        number: "2.01",
+        detect_signature: [0x08d5310e, 0xe41bdb46, 0x5a3d9627, 0xeaf8fc79, 0xe016c9e7, 0xe2eb8130],
+        algo: &DsProtAlgoV4 { reference_offset: 0x2100, unkeyed_encryption_xor: 0x7fec9df1 },
+    },
+    DsProtVersion {
+        number: "2.01 Instant",
+        detect_signature: [0x08637dd1, 0xe3618cb3, 0x5356f520, 0xe6b110ca, 0xeb4c1e5c, 0xeed91028],
+        algo: &DsProtAlgoV4 { reference_offset: 0x2100, unkeyed_encryption_xor: 0x7fec9df1 },
+    },
+    DsProtVersion {
+        number: "2.03",
+        detect_signature: [0x08b76046, 0xe4177f2f, 0x5ab21c99, 0xea2af4b1, 0xe0fe885a, 0xe202fc9e],
+        algo: &DsProtAlgoV4 { reference_offset: 0x3200, unkeyed_encryption_xor: 0x7fec9df1 },
+    },
+    DsProtVersion {
+        number: "2.03 Instant",
+        detect_signature: [0x08b76046, 0xe4177f2f, 0x5ab21c99, 0xea2af4b1, 0xe0fe885a, 0xe2029efc],
+        algo: &DsProtAlgoV4 { reference_offset: 0x3200, unkeyed_encryption_xor: 0x7fec9df1 },
+    },
+    DsProtVersion {
+        number: "2.05",
+        detect_signature: [0x08a27510, 0xe47ab3c3, 0x5a289302, 0xeaa6cac8, 0xe00d75d5, 0xe2d2fe01],
+        algo: &DsProtAlgoV4 { reference_offset: 0x2200, unkeyed_encryption_xor: 0x7fec9df1 },
+    },
+    DsProtVersion {
+        number: "2.05 Instant",
+        detect_signature: [0x08a27510, 0xe47ab3c3, 0x5a289302, 0xeaa6cac8, 0xe00d75d5, 0xe2d2fe00],
+        algo: &DsProtAlgoV4 { reference_offset: 0x2200, unkeyed_encryption_xor: 0x7fec9df1 },
+    },
+];
+
+/// Contains information about DS Protect usage.
+pub struct DsProtInfo {
+    version: &'static DsProtVersion,
+}
+
+/// Errors related to [`DsProtInfo`].
+#[derive(Debug, Snafu)]
+pub enum DsProtError {
+    /// Occurs when trying to access data outside the given module's code.
+    #[snafu(display("{what} {address:#010x} is out of bounds {base_address:#010x}..{end_address:#010x}:\n{backtrace}"))]
+    OutOfBounds {
+        /// What is being accessed.
+        what: &'static str,
+        /// The address being accessed.
+        address: u32,
+        /// The module's base address.
+        base_address: u32,
+        /// The module's end address.
+        end_address: u32,
+        /// Backtrace to the source of the error.
+        backtrace: Backtrace,
+    },
+    /// Occurs when trying to access data outside the given module's code.
+    #[snafu(display(
+        "{what} {start:#010x}..{end:#010x} is out of bounds {base_address:#010x}..{end_address:#010x}:\n{backtrace}"
+    ))]
+    RangeOutOfBounds {
+        /// What is being accessed.
+        what: &'static str,
+        /// The start of the address range being accessed.
+        start: u32,
+        /// The end of the address range being accessed.
+        end: u32,
+        /// The module's base address.
+        base_address: u32,
+        /// The module's end address.
+        end_address: u32,
+        /// Backtrace to the source of the error.
+        backtrace: Backtrace,
+    },
+    /// Occurs when the DS Protect .bss variable address was not found.
+    #[snafu(display("failed to find .bss variable address for DS Protect"))]
+    BssNotFound {
+        /// Backtrace to the source of the error.
+        backtrace: Backtrace,
+    },
+}
+
+impl DsProtInfo {
+    /// Searches for DS Protect usage in the provided module.
+    pub fn detect(data: &[u8]) -> Option<Self> {
+        // Make 32-bit chunks
+        let words: &[u32] = bytemuck::cast_slice(&data[..data.len() & !3]);
+
+        for version in DSPROT_VERSIONS {
+            // Identify if DS Protect might exist
+            if !words.windows(6).any(|window| window == version.detect_signature) {
+                continue;
+            }
+
+            return Some(Self { version });
+        }
+        None
+    }
+
+    /// Decrypts the given module's code.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if it accesses data out of bounds. This happens if the
+    /// wrong data is passed, or due to a bug in this function.
+    pub fn decrypt(&self, data: &mut [u8], base_address: u32) -> Result<DsProtDecryptDetails, DsProtError> {
+        let end_address = base_address + data.len() as u32;
+
+        // Make 32-bit chunks
+        let words: &mut [u32] = bytemuck::cast_slice_mut(data);
+
+        self.version.algo.decrypt(words, &AlgoDecryptOptions { base_address, end_address })
+    }
+
+    /// Creates a [`DisplayDsProtInfo`] which implements [`Display`].
+    pub fn display(&self, indent: usize) -> DisplayDsProtInfo<'_> {
+        DisplayDsProtInfo { info: self, indent }
+    }
+}
+
+#[derive(PartialEq, Eq)]
+enum InstructionCategory {
+    Other,
+    BlxImm,
+    Bl,
+    B,
+}
+
+impl InstructionCategory {
+    fn new(instruction: u32) -> Self {
+        let opcode = instruction >> 24;
+        if (opcode & 0x0e) != 0x0a {
+            Self::Other
+        } else if (opcode & 0xf0) == 0xf0 {
+            Self::BlxImm
+        } else if (opcode & 0x01) != 0 {
+            Self::Bl
+        } else {
+            Self::B
+        }
+    }
+}
+
+/// Can be used to display values inside [`DsProtInfo`].
+pub struct DisplayDsProtInfo<'a> {
+    info: &'a DsProtInfo,
+    indent: usize,
+}
+
+impl Display for DisplayDsProtInfo<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let i = " ".repeat(self.indent);
+        let info = &self.info;
+        writeln!(f, "{i}Version number .......... : {}", info.version.number)?;
+        Ok(())
+    }
+}
+
+struct AlgoDecryptOptions {
+    base_address: u32,
+    end_address: u32,
+}
+
+const DECRYPTION_WRAPPER_SIGNATURE_1: [u32; 3] = [0xe92d00f0, 0xe92d000f, 0xe8bd00f0];
+const DECRYPTION_WRAPPER_SIGNATURE_2: [u32; 3] = [0xe18fc00f, 0xe01cc00c, 0x03a0c000];
+
+trait DsProtAlgo {
+    fn algorithm(&self) -> DsProtAlgoVersion;
+    fn reference_offset(&self) -> u32;
+    fn integrity_check_offset(&self) -> u32;
+    fn unkeyed_encryption_xor(&self) -> u32;
+    fn unkeyed_encrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32);
+    fn unkeyed_decrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32);
+    fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32) -> u32;
+    fn init_rc4(&self, seed_key: u32, func_size: u32) -> Rc4;
+
+    // The below default implementations are for version 1.23 onwards (DsProtAlgoV2, V3 and V4), as
+    // the de/encryption procedure for those versions are essentially identical aside from the bit
+    // twiddling.
+
+    fn decrypt(&self, words: &mut [u32], options: &AlgoDecryptOptions) -> Result<DsProtDecryptDetails, DsProtError> {
+        let dsprot_bss = self.find_bss_variable(words, options)?;
+        let obfuscated_function_tables = find_obfuscated_function_tables(options, words)?;
+        let mut unkeyed_encrypted_functions =
+            self.decode_function_tables(options, words, dsprot_bss, &obfuscated_function_tables)?;
+        let mut keyed_encrypted_functions =
+            self.unkeyed_decrypt_functions(options, words, dsprot_bss, &unkeyed_encrypted_functions)?;
+        self.decrypt_wrappers(options, words, &mut keyed_encrypted_functions)?;
+
+        let mut encrypted_functions = obfuscated_function_tables;
+        encrypted_functions.append(&mut unkeyed_encrypted_functions);
+        encrypted_functions.append(&mut keyed_encrypted_functions);
+
+        Ok(DsProtDecryptDetails::Post1_23 { algorithm: self.algorithm(), dsprot_bss, encrypted_functions })
+    }
+
+    fn find_bss_variable(&self, words: &[u32], options: &AlgoDecryptOptions) -> Result<u32, DsProtError> {
+        let AlgoDecryptOptions { base_address, .. } = *options;
+
+        let signature_1 = self.unkeyed_encrypt_decryption_wrapper(DECRYPTION_WRAPPER_SIGNATURE_1);
+        let signature_2 = self.unkeyed_encrypt_decryption_wrapper(DECRYPTION_WRAPPER_SIGNATURE_2);
+
+        for (i, window) in words.windows(3).enumerate() {
+            let func_size = if window == signature_1 {
+                0x68
+            } else if window == signature_2 {
+                0x24
+            } else {
+                continue;
+            };
+            let decryption_wrapper_address = base_address + i as u32 * 4;
+            let pool_address = decryption_wrapper_address + func_size;
+
+            let pool_offset = (pool_address - base_address) as usize / 4;
+            let bss = words[pool_offset] - 1;
+            log::debug!(
+                "Found BSS variable address at {:#010x} from decryption wrapper at {:#010x}",
+                bss,
+                decryption_wrapper_address
+            );
+
+            return Ok(bss);
+        }
+
+        BssNotFoundSnafu.fail()
+    }
+
+    fn unkeyed_encrypt_decryption_wrapper(&self, signature: [u32; 3]) -> [u32; 3] {
+        let mut encrypted_signature = [0u32; 3];
+        let mut xor = self.unkeyed_encryption_xor();
+        for (i, ins) in signature.iter().enumerate() {
+            let (new_ins, new_xor) = self.unkeyed_encrypt_instruction(*ins, xor);
+            encrypted_signature[i] = new_ins;
+            xor = new_xor;
+        }
+        encrypted_signature
+    }
+
+    fn unkeyed_decrypt_functions(
+        &self,
+        options: &AlgoDecryptOptions,
+        words: &mut [u32],
+        dsprot_bss: u32,
+        unkeyed_encrypted_functions: &[EncryptedFunction],
+    ) -> Result<Vec<EncryptedFunction>, DsProtError> {
+        let AlgoDecryptOptions { base_address, end_address, .. } = *options;
+
+        let mut decryption_wrappers = Vec::new();
+        for &EncryptedFunction { address: func_address, size: func_size, encryption, constant_pool: _ } in
+            unkeyed_encrypted_functions
+        {
+            let EncryptionType::Unkeyed = encryption else { continue };
+
+            let func_offset = ((func_address - base_address) / 4) as usize;
+            let instruction_count = (func_size / 4) as usize;
+
+            let Some(func_words) = words.get_mut(func_offset..func_offset + instruction_count) else {
+                return RangeOutOfBoundsSnafu {
+                    what: "unkeyed encrypted function",
+                    start: func_address,
+                    end: func_address + func_size,
+                    base_address,
+                    end_address,
+                }
+                .fail();
+            };
+
+            let mut xor_value = self.unkeyed_encryption_xor();
+
+            log::debug!("Decrypting function at {:#010x} with size {:#x}", func_address, func_size);
+
+            for instruction in func_words.iter_mut() {
+                let (new_instruction, new_xor_value) = self.unkeyed_decrypt_instruction(*instruction, xor_value);
+                *instruction = new_instruction;
+                xor_value = new_xor_value;
+            }
+
+            let reference_offset = self.reference_offset();
+
+            if func_words.len() >= 3 && func_words[0..3] == DECRYPTION_WRAPPER_SIGNATURE_1 {
+                let pool_words = get_constant_pool(base_address, end_address, words, func_address, func_size, 4)?;
+
+                let bss = pool_words[0] - 1;
+                debug_assert_eq!(bss, dsprot_bss);
+                let dest_func_size = pool_words[1] - dsprot_bss - reference_offset;
+                let seed_key = pool_words[2] - dsprot_bss - reference_offset;
+                let dest_func_address = pool_words[3] - reference_offset;
+
+                pool_words[0] = bss;
+                pool_words[1] = dest_func_size;
+                pool_words[2] = seed_key;
+                pool_words[3] = dest_func_address;
+
+                log::debug!(
+                    "Found decryption wrapper (type 1) at {:#010x} which targets {:#010x}",
+                    func_address,
+                    dest_func_address
+                );
+                decryption_wrappers.push(EncryptedFunction {
+                    address: dest_func_address,
+                    size: dest_func_size,
+                    encryption: EncryptionType::Keyed(seed_key),
+                    constant_pool: EncodedConstantPool::DecryptionWrapperType1,
+                });
+            } else if func_words.len() >= 3 && func_words[0..3] == DECRYPTION_WRAPPER_SIGNATURE_2 {
+                let pool_words = get_constant_pool(base_address, end_address, words, func_address, func_size, 6)?;
+
+                let bss = pool_words[0] - 1;
+                debug_assert_eq!(bss, dsprot_bss);
+                let seed_key = pool_words[1] - dsprot_bss - reference_offset;
+                let dest_func_address = pool_words[2] - reference_offset;
+                let dest_func_size = pool_words[3] - dsprot_bss - reference_offset;
+                let wrapper_fragment = pool_words[5] - reference_offset;
+
+                pool_words[0] = bss;
+                pool_words[1] = seed_key;
+                pool_words[2] = dest_func_address;
+                pool_words[3] = dest_func_size;
+                pool_words[5] = wrapper_fragment;
+
+                log::debug!(
+                    "Found decryption wrapper (type 2) at {:#010x} which targets {:#010x}",
+                    func_address,
+                    dest_func_address
+                );
+                decryption_wrappers.push(EncryptedFunction {
+                    address: dest_func_address,
+                    size: dest_func_size,
+                    encryption: EncryptionType::Keyed(seed_key),
+                    constant_pool: EncodedConstantPool::DecryptionWrapperType2,
+                });
+            }
+        }
+        Ok(decryption_wrappers)
+    }
+
+    fn decode_function_tables(
+        &self,
+        options: &AlgoDecryptOptions,
+        words: &mut [u32],
+        dsprot_bss: u32,
+        obfuscated_function_tables: &[EncryptedFunction],
+    ) -> Result<Vec<EncryptedFunction>, DsProtError> {
+        let AlgoDecryptOptions { base_address, end_address, .. } = *options;
+
+        let mut encrypted_functions = Vec::new();
+        for &EncryptedFunction { address: func_address, size: func_size, encryption: _, constant_pool: _ } in
+            obfuscated_function_tables
+        {
+            let function_table_address = func_address + func_size;
+
+            log::debug!("Obfuscated function table found at {:#010x}", function_table_address);
+
+            let pool_offset = ((function_table_address - base_address) / 4) as usize;
+            let Some(pool_words) = words.get_mut(pool_offset..) else {
+                return OutOfBoundsSnafu {
+                    what: "function table",
+                    address: function_table_address,
+                    base_address,
+                    end_address,
+                }
+                .fail();
+            };
+
+            for chunk in pool_words.chunks_exact_mut(2) {
+                if chunk[0] == 0 {
+                    // End of list
+                    break;
+                }
+
+                let func_address = chunk[0] - self.reference_offset();
+                let func_size = chunk[1] - dsprot_bss - self.reference_offset();
+                log::debug!("Found unkeyed encrypted function at {:#010x}, size {:#x}", func_address, func_size);
+
+                chunk[0] = func_address;
+                chunk[1] = func_size;
+
+                encrypted_functions.push(EncryptedFunction {
+                    address: func_address,
+                    size: func_size,
+                    encryption: EncryptionType::Unkeyed,
+                    constant_pool: EncodedConstantPool::None,
+                });
+            }
+        }
+        Ok(encrypted_functions)
+    }
+
+    fn decrypt_wrappers(
+        &self,
+        options: &AlgoDecryptOptions,
+        words: &mut [u32],
+        decryption_wrappers: &mut [EncryptedFunction],
+    ) -> Result<(), DsProtError> {
+        let AlgoDecryptOptions { base_address, end_address, .. } = *options;
+
+        for function in decryption_wrappers {
+            let EncryptionType::Keyed(seed_key) = function.encryption else {
+                continue;
+            };
+
+            log::debug!(
+                "Decrypting function at {:#010x} with size {:#x} using seed key {:#06x}",
+                function.address,
+                function.size,
+                seed_key
+            );
+
+            let mut rc4 = self.init_rc4(seed_key, function.size);
+
+            // Decrypt instructions
+            let func_offset = ((function.address - base_address) / 4) as usize;
+            let func_end_offset = func_offset + (function.size / 4) as usize;
+            let Some(func_words) = words.get_mut(func_offset..func_end_offset) else {
+                return RangeOutOfBoundsSnafu {
+                    what: "encrypted function",
+                    start: function.address,
+                    end: function.address + function.size,
+                    base_address,
+                    end_address,
+                }
+                .fail();
+            };
+            for instruction in func_words.iter_mut() {
+                *instruction = self.decrypt_instruction(&mut rc4, *instruction);
+            }
+
+            // Decrypt constant pools based on function signature
+            let mut func_start = [0; 7];
+            let limit = func_start.len().min(func_words.len());
+            func_start[0..limit].copy_from_slice(&func_words[0..limit]);
+
+            let Some(pool_words) = words.get_mut(func_end_offset..) else {
+                return OutOfBoundsSnafu {
+                    what: "encrypted function constant pool",
+                    address: function.address + function.size,
+                    base_address,
+                    end_address,
+                }
+                .fail();
+            };
+
+            let reference_offset = self.reference_offset();
+
+            if func_start[0..4] == [0xe92d4ff8, 0xe24dd080, 0xe59f209c, 0xe59f109c]
+                || func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f307c, 0xe59f207c]
+            {
+                // Flashcart/Emulator detector
+                let test_fn_addr = pool_words[0] - reference_offset;
+                let integrity_fn_addr = pool_words[1] - reference_offset;
+                pool_words[0] = test_fn_addr;
+                pool_words[1] = integrity_fn_addr;
+                function.constant_pool = EncodedConstantPool::FlashcartEmulatorDetectorType1;
+                log::debug!("Decrypted flashcart/emulator detector (type 1)");
+            } else if func_start[0..4] == [0xe92d4ff8, 0xe24dd098, 0xe59f2170, 0xe59f4170] {
+                // Flashcart/Emulator detector
+                let callback_index_addr = pool_words[0] - reference_offset;
+                let callback_table_addr = pool_words[1] - reference_offset;
+                let test_fn_addr = pool_words[2] - reference_offset;
+                let integrity_fn_addr = pool_words[3] - reference_offset;
+                pool_words[0] = callback_index_addr;
+                pool_words[1] = callback_table_addr;
+                pool_words[2] = test_fn_addr;
+                pool_words[3] = integrity_fn_addr;
+                function.constant_pool = EncodedConstantPool::FlashcartEmulatorDetectorType2;
+                log::debug!("Decrypted flashcart/emulator detector (type 2)");
+            } else if func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f3070, 0xe3a02000] {
+                // Dummy detector
+                let test_fn_addr = pool_words[0] - reference_offset;
+                pool_words[0] = test_fn_addr;
+                function.constant_pool = EncodedConstantPool::DummyDetector;
+                log::debug!("Decrypted dummy detector");
+            } else if func_start[6] == 0x112fff1e {
+                // Integrity checkers
+                let checked_fn_addr = pool_words[0] - self.integrity_check_offset();
+                pool_words[0] = checked_fn_addr;
+                function.constant_pool = EncodedConstantPool::IntegrityChecker;
+                log::debug!("Decrypted integrity checker");
+            }
+            // The other function types don't have any encrypted constant pools
+        }
+        Ok(())
+    }
+}
+
+fn find_obfuscated_function_tables(
+    options: &AlgoDecryptOptions,
+    words: &mut [u32],
+) -> Result<Vec<EncryptedFunction>, DsProtError> {
+    let AlgoDecryptOptions { base_address, .. } = *options;
+
+    let mut encrypted_functions = Vec::new();
+    for (i, window) in words.windows(4).enumerate() {
+        let address = base_address + i as u32 * 4;
+        let pool_offset = if window[0..2] == [0xe38f0000, 0xe2900004] && window[2] >> 24 == 0x1a {
+            0xc
+        } else if window[0..2] == [0xe92d4000, 0xe28f0004] && window[2] >> 24 == 0xeb && window[3] == 0xe8bd8000 {
+            0x10
+        } else {
+            continue;
+        };
+        encrypted_functions.push(EncryptedFunction {
+            address,
+            size: pool_offset,
+            encryption: EncryptionType::None,
+            constant_pool: EncodedConstantPool::ObfuscatedFunctionTable,
+        });
+    }
+
+    Ok(encrypted_functions)
+}
+
+fn get_constant_pool(
+    base_address: u32,
+    end_address: u32,
+    words: &mut [u32],
+    func_address: u32,
+    func_size: u32,
+    pool_size: u32,
+) -> Result<&mut [u32], DsProtError> {
+    let pool_offset = ((func_address + func_size - base_address) / 4) as usize;
+    let wrapper_end_offset = pool_offset + pool_size as usize;
+    let Some(pool_words) = words.get_mut(pool_offset..wrapper_end_offset) else {
+        return RangeOutOfBoundsSnafu {
+            what: "decryption wrapper constant pool",
+            start: func_address + func_size,
+            end: func_address + pool_size * 4,
+            base_address,
+            end_address,
+        }
+        .fail();
+    };
+    Ok(pool_words)
+}
+
+fn encrypt_branch_1(reference_offset: u32, ins: u32) -> u32 {
+    // Flip link bit and add branch destination
+    let opcode = (ins & 0xff000000) ^ 0x01000000;
+    let operands = (ins & 0x00ffffff).wrapping_add(reference_offset) & 0x00ffffff;
+    opcode | operands
+}
+
+fn encrypt_branch_2(reference_offset: u32, ins: u32) -> u32 {
+    // Flip link bit and add branch destination
+    let opcode = (ins & 0xff000000) ^ 0x01000000;
+    let offset = (reference_offset + 8) >> 2;
+    let operands = (ins & 0x00ffffff).wrapping_add(offset) & 0x00ffffff;
+    opcode | operands
+}
+
+fn decrypt_branch_1(reference_offset: u32, ins: u32) -> u32 {
+    // Flip link bit and subtract branch destination
+    let opcode = (ins & 0xff000000) ^ 0x01000000;
+    let operands = (ins & 0x00ffffff).wrapping_sub(reference_offset) & 0x00ffffff;
+    opcode | operands
+}
+
+fn decrypt_branch_2(reference_offset: u32, ins: u32) -> u32 {
+    // Flip link bit and subtract branch destination
+    let opcode = (ins & 0xff000000) ^ 0x01000000;
+    let offset = (reference_offset + 8) >> 2;
+    let operands = (ins & 0x00ffffff).wrapping_sub(offset) & 0x00ffffff;
+    opcode | operands
+}
+
+fn expand_seed_key_old(seed_key: u32) -> [u8; 16] {
+    assert_eq!(seed_key & 0xff000000, 0xeb000000);
+    let bytes = seed_key.to_le_bytes();
+    [
+        bytes[0] ^ 0xff,
+        bytes[1],
+        bytes[2],
+        bytes[3],
+        bytes[0],
+        bytes[1],
+        bytes[2],
+        bytes[3],
+        bytes[0],
+        bytes[1],
+        bytes[2],
+        bytes[3],
+        bytes[0],
+        bytes[1],
+        bytes[2],
+        bytes[3] ^ 0xff,
+    ]
+}
+
+fn expand_seed_key(seed_key: u32, func_size: u32) -> [u32; 4] {
+    [
+        seed_key ^ func_size,
+        seed_key.rotate_left(8) ^ func_size,
+        seed_key.rotate_left(16) ^ func_size,
+        seed_key.rotate_left(24) ^ func_size,
+    ]
+}
+
+/// Defines each version of the de/encryption algorithm.
+#[derive(Serialize, Deserialize)]
+pub enum DsProtAlgoVersion {
+    /// Before 1.23
+    V1(DsProtAlgoV1),
+    /// Before 1.25
+    V2(DsProtAlgoV2),
+    /// Before 2.00
+    V3(DsProtAlgoV3),
+    /// 2.00 onwards
+    V4(DsProtAlgoV4),
+}
+
+/// Before 1.23
+#[derive(Clone, Copy, Serialize, Deserialize)]
+pub struct DsProtAlgoV1;
+
+/// Before 1.25
+#[derive(Clone, Copy, Serialize, Deserialize)]
+pub struct DsProtAlgoV2 {
+    reference_offset: u32,
+    unkeyed_encryption_xor: u32,
+}
+
+/// Before 2.00
+#[derive(Clone, Copy, Serialize, Deserialize)]
+pub struct DsProtAlgoV3 {
+    reference_offset: u32,
+    unkeyed_encryption_xor: u32,
+}
+
+/// 2.00 onwards
+#[derive(Clone, Copy, Serialize, Deserialize)]
+pub struct DsProtAlgoV4 {
+    reference_offset: u32,
+    unkeyed_encryption_xor: u32,
+}
+
+impl DsProtAlgo for DsProtAlgoV1 {
+    fn algorithm(&self) -> DsProtAlgoVersion {
+        DsProtAlgoVersion::V1(*self)
+    }
+
+    fn reference_offset(&self) -> u32 {
+        0 // unused
+    }
+
+    fn integrity_check_offset(&self) -> u32 {
+        0 // unused
+    }
+
+    fn unkeyed_encryption_xor(&self) -> u32 {
+        0 // unused
+    }
+
+    fn unkeyed_encrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32) {
+        (ins, xor) // unused
+    }
+
+    fn unkeyed_decrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32) {
+        (ins, xor) // unused
+    }
+
+    fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32) -> u32 {
+        let bytes = ins.to_le_bytes();
+        u32::from_le_bytes([rc4.decrypt_byte(bytes[0]), rc4.decrypt_byte(bytes[1]), bytes[2] ^ 0x01, bytes[3]])
+    }
+
+    fn init_rc4(&self, seed_key: u32, _func_size: u32) -> Rc4 {
+        let expanded_key = expand_seed_key_old(seed_key);
+        Rc4::new(&expanded_key, None)
+    }
+
+    fn decrypt(&self, words: &mut [u32], options: &AlgoDecryptOptions) -> Result<DsProtDecryptDetails, DsProtError> {
+        let AlgoDecryptOptions { base_address, .. } = *options;
+
+        // Find the starts and keys of all encrypted code ranges
+        let encrypted_range_starts: Vec<(u32, u32)> = words
+            .windows(7)
+            .enumerate()
+            .filter(|(_i, word)| {
+                word[0] == 0xe92d03ff
+                    && word[1] == 0xe3a00006
+                    && word[2] == 0xe08f0080
+                    && word[4] == 0xe8bd03ff
+                    && word[5] == 0xea000000
+            })
+            .map(|(i, word)| {
+                let start_address = base_address + i as u32 * 4 + 0x1c;
+                let key = word[6];
+                (start_address, key)
+            })
+            .collect();
+
+        let mut encrypted_ranges = Vec::new();
+        for (start_address, key) in encrypted_range_starts {
+            log::debug!("Found encrypted range starting at {:#010x} with key {:#010x}", start_address, key);
+
+            let mut rc4 = self.init_rc4(key, 0); // function size not needed
+
+            for address in (start_address..).step_by(4) {
+                let offset = ((address - base_address) / 4) as usize;
+                let instruction = words[offset];
+                if instruction == key {
+                    encrypted_ranges.push(EncryptedRange { start_address, end_address: address });
+                    break;
+                }
+                words[offset] = self.decrypt_instruction(&mut rc4, instruction);
+            }
+        }
+
+        Ok(DsProtDecryptDetails::Pre1_23 { encrypted_ranges })
+    }
+}
+
+impl DsProtAlgo for DsProtAlgoV2 {
+    fn algorithm(&self) -> DsProtAlgoVersion {
+        DsProtAlgoVersion::V2(*self)
+    }
+
+    fn reference_offset(&self) -> u32 {
+        self.reference_offset
+    }
+
+    fn integrity_check_offset(&self) -> u32 {
+        self.reference_offset * 2
+    }
+
+    fn unkeyed_encryption_xor(&self) -> u32 {
+        self.unkeyed_encryption_xor
+    }
+
+    fn unkeyed_encrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32) {
+        let new_ins = match InstructionCategory::new(ins) {
+            InstructionCategory::BlxImm | InstructionCategory::Bl => encrypt_branch_1(self.reference_offset, ins),
+            InstructionCategory::B => encrypt_branch_2(self.reference_offset, ins),
+            InstructionCategory::Other => ins ^ xor,
+        };
+        (new_ins, xor)
+    }
+
+    fn unkeyed_decrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32) {
+        let new_ins = match InstructionCategory::new(ins) {
+            InstructionCategory::BlxImm | InstructionCategory::Bl => decrypt_branch_1(self.reference_offset, ins),
+            InstructionCategory::B => decrypt_branch_2(self.reference_offset, ins),
+            InstructionCategory::Other => ins ^ xor,
+        };
+        (new_ins, xor)
+    }
+
+    fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32) -> u32 {
+        match InstructionCategory::new(ins) {
+            InstructionCategory::BlxImm | InstructionCategory::Bl => decrypt_branch_1(self.reference_offset, ins),
+            InstructionCategory::B => decrypt_branch_2(self.reference_offset, ins),
+            InstructionCategory::Other => {
+                let bytes = ins.to_le_bytes();
+                u32::from_le_bytes([rc4.decrypt_byte(bytes[0]), rc4.decrypt_byte(bytes[1]), bytes[2] ^ 1, bytes[3]])
+            }
+        }
+    }
+
+    fn init_rc4(&self, seed_key: u32, func_size: u32) -> Rc4 {
+        let expanded_key = expand_seed_key(seed_key, func_size);
+        Rc4::new(bytemuck::cast_slice(&expanded_key), None)
+    }
+}
+
+impl DsProtAlgo for DsProtAlgoV3 {
+    fn algorithm(&self) -> DsProtAlgoVersion {
+        DsProtAlgoVersion::V3(*self)
+    }
+
+    fn reference_offset(&self) -> u32 {
+        self.reference_offset
+    }
+
+    fn integrity_check_offset(&self) -> u32 {
+        self.reference_offset * 2
+    }
+
+    fn unkeyed_encryption_xor(&self) -> u32 {
+        self.unkeyed_encryption_xor
+    }
+
+    fn unkeyed_encrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32) {
+        match InstructionCategory::new(ins) {
+            InstructionCategory::BlxImm | InstructionCategory::B => {
+                let new_ins = decrypt_branch_2(self.reference_offset, ins);
+                (new_ins, (xor ^ (ins >> 24)) & 0xffffff)
+            }
+            InstructionCategory::Bl => {
+                let new_ins = ins ^ xor ^ 0x01000000; // flip link bit
+                (new_ins, (xor ^ ins ^ (ins >> 8)) & 0xffffff)
+            }
+            InstructionCategory::Other => {
+                let new_ins = ins ^ xor;
+                (new_ins, (xor ^ ins ^ (ins >> 8)) & 0xffffff)
+            }
+        }
+    }
+
+    fn unkeyed_decrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32) {
+        match InstructionCategory::new(ins) {
+            InstructionCategory::BlxImm | InstructionCategory::B => {
+                let new_ins = decrypt_branch_2(self.reference_offset, ins);
+                (new_ins, (xor ^ (new_ins >> 24)) & 0xffffff)
+            }
+            InstructionCategory::Bl => {
+                let new_ins = ins ^ xor ^ 0x01000000; // flip link bit
+                (new_ins, (xor ^ new_ins ^ (new_ins >> 8)) & 0xffffff)
+            }
+            InstructionCategory::Other => {
+                let new_ins = ins ^ xor;
+                (new_ins, (xor ^ new_ins ^ (new_ins >> 8)) & 0xffffff)
+            }
+        }
+    }
+
+    fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32) -> u32 {
+        match InstructionCategory::new(ins) {
+            InstructionCategory::BlxImm | InstructionCategory::B => {
+                rc4.update_x(|x| x.wrapping_add((ins >> 24) as u8));
+                decrypt_branch_2(self.reference_offset, ins)
+            }
+            category => {
+                let bytes = ins.to_le_bytes();
+                let result = u32::from_le_bytes([
+                    rc4.decrypt_byte(bytes[0]),
+                    rc4.decrypt_byte(bytes[1]),
+                    bytes[2] ^ 0xff,
+                    if category == InstructionCategory::Bl {
+                        bytes[3] ^ 0x01 // flip link bit
+                    } else {
+                        bytes[3]
+                    },
+                ]);
+                rc4.update_x(|x| bytes[2].wrapping_mul(x).wrapping_sub(bytes[3]));
+                result
+            }
+        }
+    }
+
+    fn init_rc4(&self, seed_key: u32, func_size: u32) -> Rc4 {
+        let expanded_key = expand_seed_key(seed_key, func_size);
+        Rc4::new(bytemuck::cast_slice(&expanded_key), Some(0xaa))
+    }
+}
+
+impl DsProtAlgo for DsProtAlgoV4 {
+    fn algorithm(&self) -> DsProtAlgoVersion {
+        DsProtAlgoVersion::V4(*self)
+    }
+
+    fn reference_offset(&self) -> u32 {
+        self.reference_offset
+    }
+
+    fn integrity_check_offset(&self) -> u32 {
+        self.reference_offset
+    }
+
+    fn unkeyed_encryption_xor(&self) -> u32 {
+        self.unkeyed_encryption_xor
+    }
+
+    fn unkeyed_encrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32) {
+        let new_ins = ins ^ xor;
+        let new_xor = xor ^ ins.wrapping_sub(ins >> 8);
+        (new_ins, new_xor)
+    }
+
+    fn unkeyed_decrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32) {
+        let new_ins = ins ^ xor;
+        let new_xor = xor ^ new_ins.wrapping_sub(new_ins >> 8);
+        (new_ins, new_xor)
+    }
+
+    fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32) -> u32 {
+        match InstructionCategory::new(ins) {
+            InstructionCategory::BlxImm | InstructionCategory::B => {
+                rc4.update_x(|x| x.wrapping_add((ins >> 24) as u8));
+                decrypt_branch_2(self.reference_offset, ins)
+            }
+            category => {
+                let bytes = ins.to_le_bytes();
+                let result = u32::from_le_bytes([
+                    rc4.decrypt_byte(bytes[0]),
+                    rc4.decrypt_byte(bytes[1]),
+                    rc4.decrypt_byte(bytes[2]),
+                    if category == InstructionCategory::Bl {
+                        bytes[3] ^ 0x01 // flip link bit
+                    } else {
+                        bytes[3]
+                    },
+                ]);
+                rc4.update_x(|x| x.wrapping_sub(bytes[3]));
+                result
+            }
+        }
+    }
+
+    fn init_rc4(&self, seed_key: u32, func_size: u32) -> Rc4 {
+        let expanded_key = expand_seed_key(seed_key, func_size);
+        Rc4::new(bytemuck::cast_slice(&expanded_key), Some(0xaa))
+    }
+}
+
+/// Contains complete information about how DS Protect's encrypted code was decrypted. This is used
+/// when building a ROM so the decrypted code can be re-encrypted so it matches the original ROM.
+#[derive(Serialize, Deserialize)]
+pub enum DsProtDecryptDetails {
+    /// Before DS Protect version 1.23
+    Pre1_23 {
+        /// List of encrypted ranges of instructions.
+        encrypted_ranges: Vec<EncryptedRange>,
+    },
+    /// DS Protect version 1.23 and onwards
+    Post1_23 {
+        /// Which decryption algorithm was used.
+        algorithm: DsProtAlgoVersion,
+        /// Address of the DS Protect BSS variable. Used for offsetting constants.
+        dsprot_bss: u32,
+        /// List of encrypted functions.
+        encrypted_functions: Vec<EncryptedFunction>,
+    },
+}
+
+impl DsProtDecryptDetails {
+    /// Returns a [`DisplayDsProtDecryptDetails`] which implements [`Display`].
+    pub fn display(&self, indent: usize) -> DisplayDsProtDecryptDetails<'_> {
+        DisplayDsProtDecryptDetails { inner: self, indent }
+    }
+}
+
+/// Can be used to display values inside [`DsProtDecryptDetails`].
+pub struct DisplayDsProtDecryptDetails<'a> {
+    inner: &'a DsProtDecryptDetails,
+    indent: usize,
+}
+
+impl Display for DisplayDsProtDecryptDetails<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let i = " ".repeat(self.indent);
+        let inner = self.inner;
+        match inner {
+            DsProtDecryptDetails::Pre1_23 { encrypted_ranges } => {
+                writeln!(f, "{i}Encrypted ranges .. :")?;
+                for range in encrypted_ranges {
+                    writeln!(f, "{i}  {:#010x}..{:#010x}", range.start_address, range.end_address)?;
+                }
+            }
+            DsProtDecryptDetails::Post1_23 { algorithm, dsprot_bss, encrypted_functions } => {
+                writeln!(f, "{i}BSS variable ......... : {:#010x}", dsprot_bss)?;
+                write!(f, "{i}Algorithm ............ : ")?;
+                match algorithm {
+                    DsProtAlgoVersion::V1(_algo) => {
+                        writeln!(f, "v1")?;
+                    }
+                    DsProtAlgoVersion::V2(algo) => {
+                        writeln!(
+                            f,
+                            "v2 (reference offset = {:#x}, xor = {:#x})",
+                            algo.reference_offset, algo.unkeyed_encryption_xor
+                        )?;
+                    }
+                    DsProtAlgoVersion::V3(algo) => {
+                        writeln!(
+                            f,
+                            "v3 (reference offset = {:#x}, xor = {:#x})",
+                            algo.reference_offset, algo.unkeyed_encryption_xor
+                        )?;
+                    }
+                    DsProtAlgoVersion::V4(algo) => {
+                        writeln!(
+                            f,
+                            "v4 (reference offset = {:#x}, xor = {:#x})",
+                            algo.reference_offset, algo.unkeyed_encryption_xor
+                        )?;
+                    }
+                }
+                writeln!(f, "{i}Encrypted functions .. :")?;
+                for function in encrypted_functions {
+                    writeln!(f, "{i}  Address ................ : {:#010x}", function.address)?;
+                    writeln!(f, "{i}  Size ................... : {:#x}", function.size)?;
+                    write!(f, "{i}  Encryption ............. : ")?;
+                    match function.encryption {
+                        EncryptionType::None => {
+                            writeln!(f, "None")?;
+                        }
+                        EncryptionType::Unkeyed => {
+                            writeln!(f, "Unkeyed")?;
+                        }
+                        EncryptionType::Keyed(seed_key) => {
+                            writeln!(f, "Keyed ({:#x})", seed_key)?;
+                        }
+                    }
+                    writeln!(f, "{i}  Encoded constant pool .. : {:?}\n", function.constant_pool)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// Represents an address range of encrypted instructions.
+#[derive(Serialize, Deserialize)]
+pub struct EncryptedRange {
+    start_address: u32,
+    end_address: u32,
+}
+
+/// Contains information about an encrypted function.
+#[derive(Serialize, Deserialize)]
+pub struct EncryptedFunction {
+    address: u32,
+    size: u32,
+    encryption: EncryptionType,
+    constant_pool: EncodedConstantPool,
+}
+
+/// The type of encryption used on an [`EncryptedFunction`].
+#[derive(Clone, Copy, Serialize, Deserialize)]
+pub enum EncryptionType {
+    /// No encryption, only encoded constant pool.
+    None,
+    /// Unkeyed encryption using an XOR cipher.
+    Unkeyed,
+    /// Keyed encryption using modified [`Rc4`].
+    Keyed(u32),
+}
+
+/// Represents a type of DS Protect function whose constant pool contains encoded values.
+#[derive(Debug, Serialize, Deserialize)]
+pub enum EncodedConstantPool {
+    /// No encoding, only encryption.
+    None,
+    /// Encodes an array of (function address, function size).
+    ObfuscatedFunctionTable,
+    /// Encodes BSS var address, dest function size, seed key, dest function address.
+    DecryptionWrapperType1,
+    /// Encodes BSS var address, seed key, dest function address, dest function size, wrapper fragment address.
+    DecryptionWrapperType2,
+    /// Encodes test function address, integrity checker address.
+    FlashcartEmulatorDetectorType1,
+    /// Encodes callback index address, callback table address, test function address, integrity checker address.
+    FlashcartEmulatorDetectorType2,
+    /// Encodes test function address.
+    DummyDetector,
+    /// Encodes checked function address.
+    IntegrityChecker,
+}

--- a/lib/src/crypto/dsprot.rs
+++ b/lib/src/crypto/dsprot.rs
@@ -108,6 +108,7 @@ const DSPROT_VERSIONS: &[DsProtVersion] = &[
             reference_offset: 0x3200,
             unkeyed_encryption_xor: 0x0976afcc,
             precalculated_seed_key: 0xfa8fd0ea,
+            encrypt_opcode: |curr, prev| curr ^ prev,
         },
     },
     DsProtVersion {
@@ -117,6 +118,7 @@ const DSPROT_VERSIONS: &[DsProtVersion] = &[
             reference_offset: 0x3200,
             unkeyed_encryption_xor: 0x0976afcc,
             precalculated_seed_key: 0xfa8fd0ea,
+            encrypt_opcode: |curr, prev| curr ^ prev,
         },
     },
     DsProtVersion {
@@ -126,6 +128,7 @@ const DSPROT_VERSIONS: &[DsProtVersion] = &[
             reference_offset: 0x2200,
             unkeyed_encryption_xor: 0x0a471abb,
             precalculated_seed_key: 0x89ede4ea,
+            encrypt_opcode: |curr, prev| curr.wrapping_sub(prev),
         },
     },
     DsProtVersion {
@@ -135,6 +138,7 @@ const DSPROT_VERSIONS: &[DsProtVersion] = &[
             reference_offset: 0x2200,
             unkeyed_encryption_xor: 0x0a471abb,
             precalculated_seed_key: 0x89ede4ea,
+            encrypt_opcode: |curr, prev| curr.wrapping_sub(prev),
         },
     },
 ];
@@ -240,7 +244,7 @@ impl DsProtInfo {
         // Make 32-bit chunks
         let words: &mut [u32] = bytemuck::cast_slice_mut(data);
 
-        self.version.algo.decrypt(words, &AlgoDecryptOptions { base_address, end_address })
+        self.version.algo.decrypt(words, &AlgoDecryptOptions { base_address, end_address, version: self.version.number })
     }
 
     /// Creates a [`DisplayDsProtInfo`] which implements [`Display`].
@@ -290,14 +294,15 @@ impl Display for DisplayDsProtInfo<'_> {
 struct AlgoDecryptOptions {
     base_address: u32,
     end_address: u32,
+    version: &'static str,
 }
 
 const DECRYPTION_WRAPPER_SIGNATURE_1: [u32; 3] = [0xe92d00f0, 0xe92d000f, 0xe8bd00f0];
 const DECRYPTION_WRAPPER_SIGNATURE_2: [u32; 4] = [0xe18fc00f, 0xe01cc00c, 0x03a0c000, 0x128cc01c];
 const DECRYPTION_WRAPPER_SIGNATURE_3: [u32; 4] = [0xe18fc00f, 0xe01cc00c, 0x03a0c000, 0x128cc068];
+const DECRYPTION_WRAPPER_SIGNATURE_4: [u32; 4] = [0xe18fc00f, 0xe01cc00c, 0x03a0c000, 0x128cc08c];
 
 trait DsProtAlgo {
-    fn algorithm(&self) -> DsProtAlgoVersion;
     fn reference_offset(&self) -> u32;
     fn integrity_check_offset(&self) -> u32;
     fn unkeyed_encryption_xor(&self) -> u32;
@@ -331,7 +336,7 @@ trait DsProtAlgo {
         encrypted_functions.sort_unstable_by_key(|f| f.address);
 
         Ok(DsProtDecryptDetails::Post1_23 {
-            algorithm: self.algorithm(),
+            version: options.version,
             dsprot_bss,
             encrypted_functions,
             encoded_function_pointers,
@@ -344,9 +349,11 @@ trait DsProtAlgo {
         let mut signature_1 = DECRYPTION_WRAPPER_SIGNATURE_1;
         let mut signature_2 = DECRYPTION_WRAPPER_SIGNATURE_2;
         let mut signature_3 = DECRYPTION_WRAPPER_SIGNATURE_3;
+        let mut signature_4 = DECRYPTION_WRAPPER_SIGNATURE_4;
         let signature_1 = self.unkeyed_encrypt_decryption_wrapper(&mut signature_1);
         let signature_2 = self.unkeyed_encrypt_decryption_wrapper(&mut signature_2);
         let signature_3 = self.unkeyed_encrypt_decryption_wrapper(&mut signature_3);
+        let signature_4 = self.unkeyed_encrypt_decryption_wrapper(&mut signature_4);
 
         for (i, window) in words.windows(4).enumerate() {
             let func_size = if &window[0..3] == signature_1 {
@@ -355,6 +362,8 @@ trait DsProtAlgo {
                 0x24
             } else if window == signature_3 {
                 0x70
+            } else if window == signature_4 {
+                0x94
             } else {
                 continue;
             };
@@ -540,9 +549,9 @@ trait DsProtAlgo {
                 pool_words[1] = dest_func_size;
                 pool_words[2] = seed_key;
                 pool_words[3] = dest_func_address;
+                // sanity check that this looks like a RAM address
                 let with_garbage = garbage_address >> 24 == 0x02;
                 if with_garbage {
-                    // sanity check that this looks like a RAM address
                     pool_words[4] = garbage_address;
                 }
 
@@ -574,9 +583,9 @@ trait DsProtAlgo {
                 pool_words[2] = dest_func_address;
                 pool_words[3] = dest_func_size;
                 pool_words[5] = wrapper_fragment;
+                // sanity check that this looks like a RAM address
                 let with_garbage = garbage_address >> 24 == 0x02;
                 if with_garbage {
-                    // sanity check that this looks like a RAM address
                     pool_words[6] = garbage_address;
                 }
 
@@ -592,7 +601,9 @@ trait DsProtAlgo {
                     encryption: EncryptionType::Keyed(seed_key),
                     constant_pool: EncodedConstantPool::None,
                 });
-            } else if func_words.len() >= 4 && func_words[0..4] == DECRYPTION_WRAPPER_SIGNATURE_3 {
+            } else if func_words.len() >= 4
+                && (func_words[0..4] == DECRYPTION_WRAPPER_SIGNATURE_3 || func_words[0..4] == DECRYPTION_WRAPPER_SIGNATURE_4)
+            {
                 let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 7)?;
 
                 let bss = pool_words[0] - 1;
@@ -610,38 +621,11 @@ trait DsProtAlgo {
                 pool_words[2] = dest_func_address;
                 pool_words[3] = dest_func_size;
                 pool_words[5] = wrapper_fragment;
+                // sanity check that this looks like a RAM address
                 let with_garbage = garbage_address >> 24 == 0x02;
                 if with_garbage {
-                    // sanity check that this looks like a RAM address
                     pool_words[6] = garbage_address;
                 }
-
-                // let wrapper_fragment_offset = ((wrapper_fragment - base_address) / 4) as usize;
-                // let Some(wrapper_fragment_words) =
-                //     words.get(wrapper_fragment_offset..wrapper_fragment_offset + wrapper_fragment_size as usize)
-                // else {
-                //     return RangeOutOfBoundsSnafu {
-                //         what: "wrapper fragment",
-                //         start: wrapper_fragment,
-                //         end: wrapper_fragment + wrapper_fragment_size * 4,
-                //         base_address,
-                //         end_address,
-                //     }
-                //     .fail();
-                // };
-
-                // let mut seed_key = 0;
-                // for &word in wrapper_fragment_words {
-                //     println!("WORD {:#010x}", word);
-                //     let opcode = word >> 24;
-                //     if opcode == 0xea || opcode == 0xeb {
-                //         // skip branch instructions
-                //         continue;
-                //     }
-                //     seed_key ^= word.rotate_right(17);
-                //     seed_key = seed_key.wrapping_add(word.rotate_right(28));
-                //     seed_key ^= word.rotate_right(1);
-                // }
 
                 let seed_key = self.precalculated_seed_key().unwrap();
 
@@ -730,19 +714,21 @@ trait DsProtAlgo {
                 .fail();
             };
 
-            let mut chunk_iter = pool_words.chunks_exact_mut(2);
-            for chunk in chunk_iter.by_ref() {
-                if chunk[0] == 0 {
+            let mut pool_iter = pool_words.iter_mut();
+            while let Some(first) = pool_iter.next()
+                && let Some(second) = pool_iter.next()
+            {
+                if *first == 0 {
                     // End of list
                     break;
                 }
 
-                let func_address = chunk[0] - self.reference_offset();
-                let func_size = chunk[1] - dsprot_bss - self.reference_offset();
+                let func_address = *first - self.reference_offset();
+                let func_size = *second - dsprot_bss - self.reference_offset();
                 log::debug!("Found unkeyed encrypted function at {:#010x}, size {:#x}", func_address, func_size);
 
-                chunk[0] = func_address;
-                chunk[1] = func_size;
+                *first = func_address;
+                *second = func_size;
 
                 encrypted_functions.push(EncryptedFunction {
                     address: func_address,
@@ -753,13 +739,13 @@ trait DsProtAlgo {
             }
 
             // Decode pointer to garbage data
-            if with_garbage && let Some(next_chunk) = chunk_iter.next() {
-                next_chunk[0] -= self.reference_offset();
+            if with_garbage && let Some(next_chunk) = pool_iter.next() {
+                *next_chunk -= self.reference_offset();
                 log::debug!("Decoded garbage pointer after decoder function at {:#010x}", func_address);
             }
             // Decode pointer to this decoder function
-            if with_overwrite && let Some(next_chunk) = chunk_iter.next() {
-                next_chunk[0] -= self.reference_offset();
+            if with_overwrite && let Some(next_chunk) = pool_iter.next() {
+                *next_chunk -= self.reference_offset();
                 log::debug!("Decoded overwrite pointer after decoder function at {:#010x}", func_address);
             }
         }
@@ -865,7 +851,7 @@ trait DsProtAlgo {
                 pool_words[0] = test_fn_addr;
                 function.constant_pool = EncodedConstantPool::DummyDetector;
                 log::debug!("Decrypted dummy detector");
-            } else if func_start[0..4] == [0xe92d4ff8, 0xe94dd018, 0xe59fa100, 0xe59f6100] {
+            } else if func_start[0..4] == [0xe92d4ff8, 0xe24dd018, 0xe59fa100, 0xe59f6100] {
                 // MAC and ROM integrity checkers
                 let mac_integrity_fn_addr = pool_words[0] - reference_offset;
                 let mac_test_fn_addr = pool_words[1] - reference_offset;
@@ -903,7 +889,7 @@ trait DsProtAlgo {
         words: &mut [u32],
         encoded_function_pointers: &[EncodedFunctionPointer],
     ) -> Result<(), DsProtError> {
-        let &AlgoDecryptOptions { base_address, end_address } = options;
+        let &AlgoDecryptOptions { base_address, end_address, .. } = options;
         for &encoded_fn_ptr in encoded_function_pointers.iter() {
             let Some(encoded_fn) = words.get_mut((encoded_fn_ptr.0 - base_address) as usize / 4) else {
                 return OutOfBoundsSnafu {
@@ -1005,70 +991,50 @@ fn expand_seed_key(seed_key: u32, func_size: u32) -> [u32; 4] {
     ]
 }
 
-/// Defines each version of the de/encryption algorithm.
-#[derive(Serialize, Deserialize)]
-pub enum DsProtAlgoVersion {
-    /// Before 1.23
-    V1(DsProtAlgoV1),
-    /// Before 1.25
-    V2(DsProtAlgoV2),
-    /// 1.25 only
-    V3(DsProtAlgoV3),
-    /// Before 2.00
-    V4(DsProtAlgoV4),
-    /// Before 2.03
-    V5(DsProtAlgoV5),
-    /// 2.03 onwards
-    V6(DsProtAlgoV6),
-}
-
 /// Before 1.23
-#[derive(Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy)]
 pub struct DsProtAlgoV1 {
     encrypted_range_start_signature: [u32; 5],
 }
 
 /// Before 1.25
-#[derive(Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy)]
 pub struct DsProtAlgoV2 {
     reference_offset: u32,
     unkeyed_encryption_xor: u32,
 }
 
 /// 1.25 only
-#[derive(Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy)]
 pub struct DsProtAlgoV3 {
     reference_offset: u32,
     unkeyed_encryption_xor: u32,
 }
 
 /// Before 2.00
-#[derive(Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy)]
 pub struct DsProtAlgoV4 {
     reference_offset: u32,
     unkeyed_encryption_xor: u32,
 }
 
 /// Before 2.03
-#[derive(Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy)]
 pub struct DsProtAlgoV5 {
     reference_offset: u32,
     unkeyed_encryption_xor: u32,
 }
 
 /// 2.03 onwards
-#[derive(Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy)]
 pub struct DsProtAlgoV6 {
     reference_offset: u32,
     unkeyed_encryption_xor: u32,
     precalculated_seed_key: u32,
+    encrypt_opcode: fn(curr: u8, prev: u8) -> u8,
 }
 
 impl DsProtAlgo for DsProtAlgoV1 {
-    fn algorithm(&self) -> DsProtAlgoVersion {
-        DsProtAlgoVersion::V1(*self)
-    }
-
     fn reference_offset(&self) -> u32 {
         0 // unused
     }
@@ -1104,7 +1070,7 @@ impl DsProtAlgo for DsProtAlgoV1 {
     }
 
     fn decrypt(&self, words: &mut [u32], options: &AlgoDecryptOptions) -> Result<DsProtDecryptDetails, DsProtError> {
-        let AlgoDecryptOptions { base_address, .. } = *options;
+        let AlgoDecryptOptions { base_address, version, .. } = *options;
 
         // Find the starts and keys of all encrypted code ranges
         let encrypted_range_starts: Vec<(u32, u32)> = words
@@ -1137,15 +1103,11 @@ impl DsProtAlgo for DsProtAlgoV1 {
         }
         encrypted_ranges.sort_unstable_by_key(|r| r.start_address);
 
-        Ok(DsProtDecryptDetails::Pre1_23 { encrypted_ranges })
+        Ok(DsProtDecryptDetails::Pre1_23 { version, encrypted_ranges })
     }
 }
 
 impl DsProtAlgo for DsProtAlgoV2 {
-    fn algorithm(&self) -> DsProtAlgoVersion {
-        DsProtAlgoVersion::V2(*self)
-    }
-
     fn reference_offset(&self) -> u32 {
         self.reference_offset
     }
@@ -1198,10 +1160,6 @@ impl DsProtAlgo for DsProtAlgoV2 {
 }
 
 impl DsProtAlgo for DsProtAlgoV3 {
-    fn algorithm(&self) -> DsProtAlgoVersion {
-        DsProtAlgoVersion::V3(*self)
-    }
-
     fn reference_offset(&self) -> u32 {
         self.reference_offset
     }
@@ -1278,10 +1236,6 @@ impl DsProtAlgo for DsProtAlgoV3 {
 }
 
 impl DsProtAlgo for DsProtAlgoV4 {
-    fn algorithm(&self) -> DsProtAlgoVersion {
-        DsProtAlgoVersion::V4(*self)
-    }
-
     fn reference_offset(&self) -> u32 {
         self.reference_offset
     }
@@ -1363,10 +1317,6 @@ impl DsProtAlgo for DsProtAlgoV4 {
 }
 
 impl DsProtAlgo for DsProtAlgoV5 {
-    fn algorithm(&self) -> DsProtAlgoVersion {
-        DsProtAlgoVersion::V5(*self)
-    }
-
     fn reference_offset(&self) -> u32 {
         self.reference_offset
     }
@@ -1426,10 +1376,6 @@ impl DsProtAlgo for DsProtAlgoV5 {
 }
 
 impl DsProtAlgo for DsProtAlgoV6 {
-    fn algorithm(&self) -> DsProtAlgoVersion {
-        DsProtAlgoVersion::V6(*self)
-    }
-
     fn reference_offset(&self) -> u32 {
         self.reference_offset
     }
@@ -1456,7 +1402,9 @@ impl DsProtAlgo for DsProtAlgoV6 {
 
     fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32, prev_ins: u32) -> u32 {
         let opcode = (ins >> 24) as u8;
-        let ins = ins ^ (prev_ins & 0xff000000);
+        let prev_opcode = (prev_ins >> 24) as u8;
+        let new_opcode = (self.encrypt_opcode)(opcode, prev_opcode);
+        let ins = (ins & 0xffffff) | ((new_opcode as u32) << 24);
         let category = InstructionCategory::new(ins);
         let new_ins = match category {
             InstructionCategory::BlxImm | InstructionCategory::B => decrypt_branch_2(self.reference_offset, ins),
@@ -1493,13 +1441,15 @@ impl DsProtAlgo for DsProtAlgoV6 {
 pub enum DsProtDecryptDetails {
     /// Before DS Protect version 1.23
     Pre1_23 {
+        /// The DS Protect version number.
+        version: &'static str,
         /// List of encrypted ranges of instructions.
         encrypted_ranges: Vec<EncryptedRange>,
     },
     /// DS Protect version 1.23 and onwards
     Post1_23 {
-        /// Which decryption algorithm was used.
-        algorithm: DsProtAlgoVersion,
+        /// The DS Protect version number.
+        version: &'static str,
         /// Address of the DS Protect BSS variable. Used for offsetting constants.
         dsprot_bss: u32,
         /// List of encrypted functions.
@@ -1527,55 +1477,16 @@ impl Display for DisplayDsProtDecryptDetails<'_> {
         let i = " ".repeat(self.indent);
         let inner = self.inner;
         match inner {
-            DsProtDecryptDetails::Pre1_23 { encrypted_ranges } => {
+            DsProtDecryptDetails::Pre1_23 { version, encrypted_ranges } => {
+                writeln!(f, "{i}Version ........... : {}", version)?;
                 writeln!(f, "{i}Encrypted ranges .. :")?;
                 for range in encrypted_ranges {
                     writeln!(f, "{i}  {:#010x}..{:#010x}", range.start_address, range.end_address)?;
                 }
             }
-            DsProtDecryptDetails::Post1_23 { algorithm, dsprot_bss, encrypted_functions, encoded_function_pointers } => {
+            DsProtDecryptDetails::Post1_23 { version, dsprot_bss, encrypted_functions, encoded_function_pointers } => {
+                writeln!(f, "{i}Version .................... : {}", version)?;
                 writeln!(f, "{i}BSS variable ............... : {:#010x}", dsprot_bss)?;
-                write!(f, "{i}Algorithm .................. : ")?;
-                match algorithm {
-                    DsProtAlgoVersion::V1(_algo) => {
-                        writeln!(f, "v1")?;
-                    }
-                    DsProtAlgoVersion::V2(algo) => {
-                        writeln!(
-                            f,
-                            "v2 (reference offset = {:#x}, xor = {:#x})",
-                            algo.reference_offset, algo.unkeyed_encryption_xor
-                        )?;
-                    }
-                    DsProtAlgoVersion::V3(algo) => {
-                        writeln!(
-                            f,
-                            "v3 (reference offset = {:#x}, xor = {:#x})",
-                            algo.reference_offset, algo.unkeyed_encryption_xor
-                        )?;
-                    }
-                    DsProtAlgoVersion::V4(algo) => {
-                        writeln!(
-                            f,
-                            "v4 (reference offset = {:#x}, xor = {:#x})",
-                            algo.reference_offset, algo.unkeyed_encryption_xor
-                        )?;
-                    }
-                    DsProtAlgoVersion::V5(algo) => {
-                        writeln!(
-                            f,
-                            "v5 (reference offset = {:#x}, xor = {:#x})",
-                            algo.reference_offset, algo.unkeyed_encryption_xor
-                        )?;
-                    }
-                    DsProtAlgoVersion::V6(algo) => {
-                        writeln!(
-                            f,
-                            "v6 (reference offset = {:#x}, xor = {:#x}, seed_key = {:#x})",
-                            algo.reference_offset, algo.unkeyed_encryption_xor, algo.precalculated_seed_key
-                        )?;
-                    }
-                }
                 writeln!(f, "{i}Encrypted functions ........ :")?;
                 for function in encrypted_functions {
                     writeln!(f, "{i}  Address ................ : {:#010x}", function.address)?;

--- a/lib/src/crypto/dsprot.rs
+++ b/lib/src/crypto/dsprot.rs
@@ -431,7 +431,6 @@ const DECRYPTION_WRAPPER_SIGNATURE_4: [u32; 4] = [0xe18fc00f, 0xe01cc00c, 0x03a0
 
 trait DsProtAlgo {
     fn reference_offset(&self) -> u32;
-    fn integrity_check_offset(&self) -> u32;
     fn unkeyed_encryption_xor(&self) -> u32;
     fn unkeyed_encrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32);
     fn unkeyed_decrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32);
@@ -795,7 +794,7 @@ trait DsProtAlgo {
                         addend: reference_offset,
                     });
                 }
-                function.pool_size = Some(0x14 + has_garbage as u32 * 4);
+                function.pool_size = Some(0x10 + has_garbage as u32 * 4);
 
                 log::debug!(
                     "Found decryption wrapper (type 1) at {:#010x} which targets {:#010x}",
@@ -1224,13 +1223,13 @@ trait DsProtAlgo {
                     addend: reference_offset,
                 });
             } else if func_start[6] == 0x112fff1e {
-                let checked_fn_addr = pool_words[0] - self.integrity_check_offset();
+                let checked_fn_addr = pool_words[0] - reference_offset;
                 log::debug!("Decrypted integrity checker for {:#010x}", checked_fn_addr);
 
                 relocations.push(DsProtRelocation {
                     from_address: function_end_address,
                     to_address: checked_fn_addr,
-                    addend: self.integrity_check_offset(),
+                    addend: reference_offset,
                 });
             } else if func_start[0..4] == [0xe1a0a00f, 0xe19aa00a, 0x102ee00e, 0xe25aa008] {
                 log::debug!("Decrypted crash function");
@@ -1420,10 +1419,6 @@ impl DsProtAlgo for DsProtAlgoV1 {
         0 // unused
     }
 
-    fn integrity_check_offset(&self) -> u32 {
-        0 // unused
-    }
-
     fn unkeyed_encryption_xor(&self) -> u32 {
         0 // unused
     }
@@ -1504,10 +1499,6 @@ impl DsProtAlgo for DsProtAlgoV2 {
         self.reference_offset
     }
 
-    fn integrity_check_offset(&self) -> u32 {
-        self.reference_offset
-    }
-
     fn unkeyed_encryption_xor(&self) -> u32 {
         self.unkeyed_encryption_xor
     }
@@ -1565,10 +1556,6 @@ impl DsProtAlgo for DsProtAlgoV2 {
 impl DsProtAlgo for DsProtAlgoV3 {
     fn reference_offset(&self) -> u32 {
         self.reference_offset
-    }
-
-    fn integrity_check_offset(&self) -> u32 {
-        self.reference_offset * 2
     }
 
     fn unkeyed_encryption_xor(&self) -> u32 {
@@ -1660,10 +1647,6 @@ impl DsProtAlgo for DsProtAlgoV3 {
 impl DsProtAlgo for DsProtAlgoV4 {
     fn reference_offset(&self) -> u32 {
         self.reference_offset
-    }
-
-    fn integrity_check_offset(&self) -> u32 {
-        self.reference_offset * 2
     }
 
     fn unkeyed_encryption_xor(&self) -> u32 {
@@ -1769,10 +1752,6 @@ impl DsProtAlgo for DsProtAlgoV5 {
         self.reference_offset
     }
 
-    fn integrity_check_offset(&self) -> u32 {
-        self.reference_offset
-    }
-
     fn unkeyed_encryption_xor(&self) -> u32 {
         self.unkeyed_encryption_xor
     }
@@ -1851,10 +1830,6 @@ impl DsProtAlgo for DsProtAlgoV5 {
 
 impl DsProtAlgo for DsProtAlgoV6 {
     fn reference_offset(&self) -> u32 {
-        self.reference_offset
-    }
-
-    fn integrity_check_offset(&self) -> u32 {
         self.reference_offset
     }
 
@@ -2129,8 +2104,10 @@ pub enum DsProtState {
     #[default]
     None,
     /// Present and unencrypted.
+    #[serde(rename = "unencrypted")]
     Unencrypted(DsProtDecryptResult),
     /// Present and encrypted.
+    #[serde(rename = "encrypted")]
     Encrypted(DsProtDecryptResult),
 }
 

--- a/lib/src/crypto/dsprot.rs
+++ b/lib/src/crypto/dsprot.rs
@@ -695,15 +695,18 @@ trait DsProtAlgo {
                 return DecoderOverwriteAddressNotFoundSnafu { decoder_address: address - fn_offset }.fail();
             }
 
+            let length = (table_end_address - pool_address) / 8;
+            let has_garbage = garbage_address.is_some();
+            let has_overwrite = overwrite_address.is_some();
+
             function_tables.push(DsProtFunction {
                 address: address - fn_offset,
                 size: pool_offset + fn_offset,
+                // has_overwrite is 8 bytes because 4 bytes for overwrite address and 4 bytes for
+                // return instruction literal (0xe12fff1e <bx lr>)
+                pool_size: Some(length * 8 + has_garbage as u32 * 4 + has_overwrite as u32 * 8),
                 encryption: EncryptionType::None,
-                function_table: Some(FunctionTable {
-                    length: (table_end_address - pool_address) / 8,
-                    has_garbage: garbage_address.is_some(),
-                    has_overwrite: overwrite_address.is_some(),
-                }),
+                function_table: Some(FunctionTable { length, has_garbage, has_overwrite }),
             });
         }
 
@@ -792,6 +795,7 @@ trait DsProtAlgo {
                         addend: reference_offset,
                     });
                 }
+                function.pool_size = Some(0x14 + has_garbage as u32 * 4);
 
                 log::debug!(
                     "Found decryption wrapper (type 1) at {:#010x} which targets {:#010x}",
@@ -801,6 +805,7 @@ trait DsProtAlgo {
                 decryption_wrappers.push(DsProtFunction {
                     address: dest_func_address,
                     size: dest_func_size,
+                    pool_size: None,
                     encryption: EncryptionType::Keyed(seed_key),
                     function_table: None,
                 });
@@ -852,6 +857,7 @@ trait DsProtAlgo {
                         addend: reference_offset,
                     });
                 }
+                function.pool_size = Some(0x18 + has_garbage as u32 * 4);
 
                 log::debug!(
                     "Found decryption wrapper (type 2) at {:#010x} which targets {:#010x}",
@@ -861,6 +867,7 @@ trait DsProtAlgo {
                 decryption_wrappers.push(DsProtFunction {
                     address: dest_func_address,
                     size: dest_func_size,
+                    pool_size: None,
                     encryption: EncryptionType::Keyed(seed_key),
                     function_table: None,
                 });
@@ -915,6 +922,7 @@ trait DsProtAlgo {
                         addend: reference_offset,
                     });
                 }
+                function.pool_size = Some(0x18 + has_garbage as u32 * 4);
 
                 let seed_key = self.precalculated_seed_key().unwrap();
 
@@ -930,6 +938,7 @@ trait DsProtAlgo {
                 decryption_wrappers.push(DsProtFunction {
                     address: dest_func_address,
                     size: dest_func_size,
+                    pool_size: None,
                     encryption: EncryptionType::Keyed(seed_key),
                     function_table: None,
                 });
@@ -1034,6 +1043,7 @@ trait DsProtAlgo {
                 functions.push(DsProtFunction {
                     address: func_address,
                     size: func_size,
+                    pool_size: None,
                     encryption: EncryptionType::Unkeyed,
                     function_table: None,
                 });
@@ -1998,9 +2008,9 @@ impl Display for DisplayDsProtDecryptResult<'_> {
         if !inner.functions.is_empty() {
             writeln!(f, "{i}Functions .................. :")?;
             for function in &inner.functions {
-                writeln!(f, "{i}  Address ..... : {:#010x}", function.address)?;
-                writeln!(f, "{i}  Size ........ : {:#x}", function.size)?;
-                write!(f, "{i}  Encryption .. : ")?;
+                writeln!(f, "{i}  Address ......... : {:#010x}", function.address)?;
+                writeln!(f, "{i}  Size ............ : {:#x}", function.size)?;
+                write!(f, "{i}  Encryption ...... : ")?;
                 match function.encryption {
                     EncryptionType::None => {
                         writeln!(f, "None")?;
@@ -2011,6 +2021,15 @@ impl Display for DisplayDsProtDecryptResult<'_> {
                     EncryptionType::Keyed(seed_key) => {
                         writeln!(f, "Keyed ({:#x})", seed_key)?;
                     }
+                }
+                write!(f, "{i}  Function table .. : ")?;
+                if let Some(function_table) = &function.function_table {
+                    writeln!(f)?;
+                    writeln!(f, "{i}    Length ......... : {}", function_table.length)?;
+                    writeln!(f, "{i}    Has garbage .... : {}", function_table.has_garbage)?;
+                    writeln!(f, "{i}    Has overwrite .. : {}", function_table.has_overwrite)?;
+                } else {
+                    writeln!(f, "None")?;
                 }
                 writeln!(f)?;
             }
@@ -2056,6 +2075,8 @@ pub struct DsProtFunction {
     pub address: u32,
     /// This function's size, excluding constant pool.
     pub size: u32,
+    /// The size in bytes of this function's constant pool, if known.
+    pub pool_size: Option<u32>,
     /// The type of encryption applied to this function.
     pub encryption: EncryptionType,
     /// If this function is a decoder which performs unkeyed decryption on a list of functions, then

--- a/lib/src/crypto/dsprot.rs
+++ b/lib/src/crypto/dsprot.rs
@@ -512,6 +512,7 @@ trait DsProtAlgo {
                 size: pool_offset + fn_offset,
                 encryption: EncryptionType::None,
                 constant_pool: EncodedConstantPool::ObfuscatedFunctionTable {
+                    length: (table_end_address - pool_address) / 8,
                     with_garbage: garbage_address.is_some(),
                     with_overwrite: overwrite_address.is_some(),
                 },
@@ -730,7 +731,7 @@ trait DsProtAlgo {
         for &EncryptedFunction { address: func_address, size: func_size, encryption: _, constant_pool } in
             obfuscated_function_tables
         {
-            let EncodedConstantPool::ObfuscatedFunctionTable { with_garbage, with_overwrite } = constant_pool else {
+            let EncodedConstantPool::ObfuscatedFunctionTable { length, with_garbage, with_overwrite } = constant_pool else {
                 continue;
             };
 
@@ -750,11 +751,14 @@ trait DsProtAlgo {
             };
 
             let mut pool_iter = pool_words.iter_mut();
-            while let Some(first) = pool_iter.next()
-                && let Some(second) = pool_iter.next()
-            {
-                if *first == 0 {
-                    // End of list
+            for _ in 0..length {
+                let Some(first) = pool_iter.next() else {
+                    break;
+                };
+                let Some(second) = pool_iter.next() else {
+                    break;
+                };
+                if *first == 0 && *second == 0 {
                     break;
                 }
 
@@ -1599,6 +1603,8 @@ pub enum EncodedConstantPool {
     None,
     /// Encodes an array of (function address, function size).
     ObfuscatedFunctionTable {
+        /// The number of (function address, function size) entries.
+        length: u32,
         /// If true, a pointer to DS Protect's garbage data was appended to the end of the constant pool.
         with_garbage: bool,
         /// If true, a pointer to this decoder function was appended to the end of the constant pool.

--- a/lib/src/crypto/dsprot.rs
+++ b/lib/src/crypto/dsprot.rs
@@ -10,135 +10,228 @@ use snafu::Snafu;
 use crate::crypto::rc4::Rc4;
 
 struct DsProtVersion {
-    number: &'static str,
+    number: DsProtVersionNumber,
     detect_signature: [u32; 6],
     algo: &'static dyn DsProtAlgo,
 }
 
+/// Represents all known versions of DS Protect
+#[derive(Serialize, Deserialize, Clone, Copy, derive_more::Display, PartialEq, Eq, Debug)]
+pub enum DsProtVersionNumber {
+    /// 1.00 or 1.02
+    #[serde(rename = "1.00")]
+    #[display("1.00")]
+    V1_00,
+    /// 1.05
+    #[serde(rename = "1.05")]
+    #[display("1.05")]
+    V1_05,
+    /// 1.06
+    #[serde(rename = "1.06")]
+    #[display("1.06")]
+    V1_06,
+    /// 1.08
+    #[serde(rename = "1.08")]
+    #[display("1.08")]
+    V1_08,
+    /// 1.10
+    #[serde(rename = "1.10")]
+    #[display("1.10")]
+    V1_10,
+    /// 1.20
+    #[serde(rename = "1.20")]
+    #[display("1.20")]
+    V1_20,
+    /// 1.22
+    #[serde(rename = "1.22")]
+    #[display("1.22")]
+    V1_22,
+    /// 1.23
+    #[serde(rename = "1.23")]
+    #[display("1.23")]
+    V1_23,
+    /// 1.23z
+    #[serde(rename = "1.23z")]
+    #[display("1.23z")]
+    V1_23Z,
+    /// 1.25
+    #[serde(rename = "1.25")]
+    #[display("1.25")]
+    V1_25,
+    /// 1.26
+    #[serde(rename = "1.26")]
+    #[display("1.26")]
+    V1_26,
+    /// 1.27
+    #[serde(rename = "1.27")]
+    #[display("1.27")]
+    V1_27,
+    /// 1.28
+    #[serde(rename = "1.28")]
+    #[display("1.28")]
+    V1_28,
+    /// 2.00
+    #[serde(rename = "2.00")]
+    #[display("2.00")]
+    V2_00,
+    /// 2.00 Instant
+    #[serde(rename = "2.00 Instant")]
+    #[display("2.00 Instant")]
+    V2_00Instant,
+    /// 2.01
+    #[serde(rename = "2.01")]
+    #[display("2.01")]
+    V2_01,
+    /// 2.01 Instant
+    #[serde(rename = "2.01 Instant")]
+    #[display("2.01 Instant")]
+    V2_01Instant,
+    /// 2.03
+    #[serde(rename = "2.03")]
+    #[display("2.03")]
+    V2_03,
+    /// 2.03 Instant
+    #[serde(rename = "2.03 Instant")]
+    #[display("2.03 Instant")]
+    V2_03Instant,
+    /// 2.05
+    #[serde(rename = "2.05")]
+    #[display("2.05")]
+    V2_05,
+    /// 2.05 Instant
+    #[serde(rename = "2.05 Instant")]
+    #[display("2.05 Instant")]
+    V2_05Instant,
+}
+
 const DSPROT_VERSIONS: &[DsProtVersion] = &[
     DsProtVersion {
-        number: "1.00",
+        number: DsProtVersionNumber::V1_00,
         detect_signature: [0xe3527270, 0xbafe77fc, 0xe59e0989, 0xe1c2f9af, 0xea018a51, 0xeb004ae2],
         algo: &DsProtAlgoV1 { encrypted_range_start_signature: [0xe92d0001, 0xe1a0000f, 0xe2800010, 0xe8bd0001, 0xea000000] },
     },
     DsProtVersion {
-        number: "1.05",
+        number: DsProtVersionNumber::V1_05,
         detect_signature: [0xbafe0f18, 0xe59caf7a, 0xe2861884, 0xe1c5da54, 0xea018a6b, 0xeb0070c2],
         algo: &DsProtAlgoV1 { encrypted_range_start_signature: [0xe92d0001, 0xe3a0000c, 0xe080000f, 0xe8bd0001, 0xea000000] },
     },
     DsProtVersion {
-        number: "1.06",
+        number: DsProtVersionNumber::V1_06,
         detect_signature: [0xbafe9b10, 0xe59cfa77, 0xe2862a71, 0xe1c54e3d, 0xea01879d, 0xeb005fdf],
         algo: &DsProtAlgoV1 { encrypted_range_start_signature: [0xe92d000f, 0xe3a0100c, 0xe081000f, 0xe8bd000f, 0xea000000] },
     },
     DsProtVersion {
-        number: "1.08",
+        number: DsProtVersionNumber::V1_08,
         detect_signature: [0xbafe4040, 0xe59c2300, 0xe2852226, 0xe1c5cbe8, 0xea01612f, 0xeb004979],
         algo: &DsProtAlgoV1 { encrypted_range_start_signature: [0xe92d00ff, 0xe1a0000f, 0xe2800010, 0xe8bd00ff, 0xea000000] },
     },
     DsProtVersion {
-        number: "1.10",
+        number: DsProtVersionNumber::V1_10,
         detect_signature: [0xbafe29a2, 0xe59cc95b, 0xe285d70a, 0xe1c5442c, 0xea01fd7e, 0xeb001cfc],
         algo: &DsProtAlgoV1 { encrypted_range_start_signature: [0xe92d00ff, 0xe3a00006, 0xe08f0080, 0xe8bd00ff, 0xea000000] },
     },
     DsProtVersion {
-        number: "1.20",
+        number: DsProtVersionNumber::V1_20,
         detect_signature: [0xe3580f00, 0xbafe7df8, 0xe284dff9, 0xe1c2059d, 0xea014de4, 0xeb002f0c],
         algo: &DsProtAlgoV1 { encrypted_range_start_signature: [0xe92d03ff, 0xe3a00006, 0xe08f0080, 0xe8bd03ff, 0xea000000] },
     },
     DsProtVersion {
-        number: "1.22",
+        number: DsProtVersionNumber::V1_22,
         detect_signature: [0xe3581567, 0xbafee339, 0xe284dad2, 0xe1c27622, 0xea017231, 0xeb0037ee],
         algo: &DsProtAlgoV1 { encrypted_range_start_signature: [0xe92d03ff, 0xe3a00003, 0xe08f0100, 0xe8bd03ff, 0xea000000] },
     },
     DsProtVersion {
-        number: "1.23",
+        number: DsProtVersionNumber::V1_23,
         detect_signature: [0xebaa0113, 0xe4064ec7, 0xef013596, 0xe5212f83, 0xe7ee335b, 0xe83b197c],
         algo: &DsProtAlgoV2 { reference_offset: 0x1300, unkeyed_encryption_xor: 0xf0566556 },
     },
     DsProtVersion {
-        number: "1.23z",
+        number: DsProtVersionNumber::V1_23Z,
         detect_signature: [0xebaa0114, 0x40064eb7, 0x5f013696, 0xe5211f83, 0xe7ef335b, 0xe84b197c],
         algo: &DsProtAlgoV2 { reference_offset: 0x1400, unkeyed_encryption_xor: 0xd0685665 },
     },
     DsProtVersion {
-        number: "1.25",
+        number: DsProtVersionNumber::V1_25,
         detect_signature: [0xebb6df66, 0xe42f6211, 0xef56b5aa, 0xe5b903fd, 0xe7d29154, 0xe859697c],
         algo: &DsProtAlgoV3 { reference_offset: 0x1500, unkeyed_encryption_xor: 0xf0556655 },
     },
     DsProtVersion {
-        number: "1.26",
+        number: DsProtVersionNumber::V1_26,
         detect_signature: [0xeb8fbc31, 0xe4ec10cf, 0xef73e592, 0xe59a0b7e, 0xe78cb309, 0xe87f3ed1],
         algo: &DsProtAlgoV4 { reference_offset: 0x1200, unkeyed_encryption_xor: 0xf03852cb },
     },
     DsProtVersion {
-        number: "1.27",
+        number: DsProtVersionNumber::V1_27,
         detect_signature: [0xe8dffe17, 0xe43df0de, 0x2ae8335c, 0x0ac09826, 0xe7a838dc, 0xe891a6fc],
         algo: &DsProtAlgoV4 { reference_offset: 0x1600, unkeyed_encryption_xor: 0xf0618c46 },
     },
     DsProtVersion {
-        number: "1.28",
+        number: DsProtVersionNumber::V1_28,
         detect_signature: [0xe2ed720b, 0xef69d1b1, 0x2ec32a41, 0x1aa3e665, 0xe9e1c153, 0xe49e8d9c],
         algo: &DsProtAlgoV4 { reference_offset: 0x1000, unkeyed_encryption_xor: 0xf0b9a2ea },
     },
     DsProtVersion {
-        number: "2.00",
+        number: DsProtVersionNumber::V2_00,
         detect_signature: [0x0819ff33, 0xe4a1ef1c, 0x5a85a2b3, 0xea0d2a0f, 0xe0d6bd78, 0xe29d9377],
         algo: &DsProtAlgoV5 { reference_offset: 0x1700, unkeyed_encryption_xor: 0xa5ca49b3 },
     },
     DsProtVersion {
-        number: "2.00 Instant",
+        number: DsProtVersionNumber::V2_00Instant,
         detect_signature: [0x0849ea8b, 0xe33b6243, 0x53b2d501, 0xe6847168, 0xebd886d7, 0xee3c09c0],
         algo: &DsProtAlgoV5 { reference_offset: 0x1700, unkeyed_encryption_xor: 0xa5ca49b3 },
     },
     DsProtVersion {
-        number: "2.01",
+        number: DsProtVersionNumber::V2_01,
         detect_signature: [0x08d5310e, 0xe41bdb46, 0x5a3d9627, 0xeaf8fc79, 0xe016c9e7, 0xe2eb8130],
         algo: &DsProtAlgoV5 { reference_offset: 0x2100, unkeyed_encryption_xor: 0x7fec9df1 },
     },
     DsProtVersion {
-        number: "2.01 Instant",
+        number: DsProtVersionNumber::V2_01Instant,
         detect_signature: [0x08637dd1, 0xe3618cb3, 0x5356f520, 0xe6b110ca, 0xeb4c1e5c, 0xeed91028],
         algo: &DsProtAlgoV5 { reference_offset: 0x2100, unkeyed_encryption_xor: 0x7fec9df1 },
     },
     DsProtVersion {
-        number: "2.03",
+        number: DsProtVersionNumber::V2_03,
         detect_signature: [0x08b76046, 0xe4177f2f, 0x5ab21c99, 0xea2af4b1, 0xe0fe885a, 0xe202fc9e],
         algo: &DsProtAlgoV6 {
             reference_offset: 0x3200,
             unkeyed_encryption_xor: 0x0976afcc,
             precalculated_seed_key: 0xfa8fd0ea,
+            decrypt_opcode: |curr, prev| curr ^ prev,
             encrypt_opcode: |curr, prev| curr ^ prev,
         },
     },
     DsProtVersion {
-        number: "2.03 Instant",
+        number: DsProtVersionNumber::V2_03Instant,
         detect_signature: [0x08b76046, 0xe4177f2f, 0x5ab21c99, 0xea2af4b1, 0xe0fe885a, 0xe2029efc],
         algo: &DsProtAlgoV6 {
             reference_offset: 0x3200,
             unkeyed_encryption_xor: 0x0976afcc,
             precalculated_seed_key: 0xfa8fd0ea,
+            decrypt_opcode: |curr, prev| curr ^ prev,
             encrypt_opcode: |curr, prev| curr ^ prev,
         },
     },
     DsProtVersion {
-        number: "2.05",
+        number: DsProtVersionNumber::V2_05,
         detect_signature: [0x08a27510, 0xe47ab3c3, 0x5a289302, 0xeaa6cac8, 0xe00d75d5, 0xe2d2fe01],
         algo: &DsProtAlgoV6 {
             reference_offset: 0x2200,
             unkeyed_encryption_xor: 0x0a471abb,
             precalculated_seed_key: 0x89ede4ea,
-            encrypt_opcode: |curr, prev| curr.wrapping_sub(prev),
+            decrypt_opcode: |curr, prev| curr.wrapping_sub(prev),
+            encrypt_opcode: |curr, prev| curr.wrapping_add(prev),
         },
     },
     DsProtVersion {
-        number: "2.05 Instant",
+        number: DsProtVersionNumber::V2_05Instant,
         detect_signature: [0x08a27510, 0xe47ab3c3, 0x5a289302, 0xeaa6cac8, 0xe00d75d5, 0xe2d2fe00],
         algo: &DsProtAlgoV6 {
             reference_offset: 0x2200,
             unkeyed_encryption_xor: 0x0a471abb,
             precalculated_seed_key: 0x89ede4ea,
-            encrypt_opcode: |curr, prev| curr.wrapping_sub(prev),
+            decrypt_opcode: |curr, prev| curr.wrapping_sub(prev),
+            encrypt_opcode: |curr, prev| curr.wrapping_add(prev),
         },
     },
 ];
@@ -252,12 +345,12 @@ impl DsProtInfo {
     ///
     /// This function will return an error if it accesses data out of bounds. This happens if the
     /// wrong data is passed, or due to a bug in this function.
-    pub fn decrypt(
+    pub(crate) fn decrypt(
         &self,
         data: &mut [u8],
         base_address: u32,
         options: &DecryptOptions,
-    ) -> Result<DsProtDecryptDetails, DsProtError> {
+    ) -> Result<DsProtDecryptResult, DsProtError> {
         let end_address = base_address + data.len() as u32;
 
         // Make 32-bit chunks
@@ -319,8 +412,13 @@ impl Display for DisplayDsProtInfo<'_> {
 struct AlgoDecryptOptions {
     base_address: u32,
     end_address: u32,
-    version: &'static str,
+    version: DsProtVersionNumber,
     decode_literals: bool,
+}
+
+struct AlgoEncryptOptions {
+    base_address: u32,
+    end_address: u32,
 }
 
 const DECRYPTION_WRAPPER_SIGNATURE_1: [u32; 3] = [0xe92d00f0, 0xe92d000f, 0xe8bd00f0];
@@ -335,15 +433,15 @@ trait DsProtAlgo {
     fn unkeyed_encrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32);
     fn unkeyed_decrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32);
     fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32, prev_ins: u32) -> u32;
+    fn encrypt_instruction(&self, rc4: &mut Rc4, ins: u32, prev_ins: u32) -> u32;
     fn precalculated_seed_key(&self) -> Option<u32>;
     fn init_rc4(&self, seed_key: u32, func_size: u32) -> Rc4;
 
-    // The below default implementations are for version 1.23 onwards (DsProtAlgoV2, V3 and V4), as
-    // the de/encryption procedure for those versions are essentially identical aside from the bit
+    // The below default implementations are for version 1.23 onwards (DsProtAlgoV2 and up), as
     // the de/encryption procedure for those versions are essentially identical aside from the bit
     // twiddling.
 
-    fn decrypt(&self, words: &mut [u32], options: &AlgoDecryptOptions) -> Result<DsProtDecryptDetails, DsProtError> {
+    fn decrypt(&self, words: &mut [u32], options: &AlgoDecryptOptions) -> Result<DsProtDecryptResult, DsProtError> {
         let dsprot_bss = self.find_bss_variable(words, options)?;
         let obfuscated_function_tables = self.find_obfuscated_function_tables(options, words)?;
         let mut unkeyed_encrypted_functions =
@@ -361,12 +459,76 @@ trait DsProtAlgo {
         encrypted_functions.append(&mut keyed_encrypted_functions);
         encrypted_functions.sort_unstable_by_key(|f| f.address);
 
-        Ok(DsProtDecryptDetails::Post1_23 {
+        Ok(DsProtDecryptResult {
             version: options.version,
-            dsprot_bss,
+            encrypted_ranges: Vec::new(),
+            bss_variable: Some(dsprot_bss),
             encrypted_functions,
             encoded_function_pointers,
         })
+    }
+
+    fn encrypt(
+        &self,
+        words: &mut [u32],
+        decrypt_result: &DsProtDecryptResult,
+        options: &AlgoEncryptOptions,
+    ) -> Result<(), DsProtError> {
+        for function in &decrypt_result.encrypted_functions {
+            let start_offset = (function.address - options.base_address) as usize / 4;
+            let end_offset = start_offset + function.size as usize / 4;
+            let instructions = words.get_mut(start_offset..end_offset).ok_or_else(|| {
+                RangeOutOfBoundsSnafu {
+                    what: "function to encrypt",
+                    start: function.address,
+                    end: function.address + function.size,
+                    base_address: options.base_address,
+                    end_address: options.end_address,
+                }
+                .build()
+            })?;
+            match function.encryption {
+                EncryptionType::None => continue,
+                EncryptionType::Unkeyed => {
+                    let mut xor = self.unkeyed_encryption_xor();
+                    for ins in instructions {
+                        let (new_ins, new_xor) = self.unkeyed_encrypt_instruction(*ins, xor);
+                        *ins = new_ins;
+                        xor = new_xor;
+                    }
+                }
+                EncryptionType::Keyed(seed_key) => {
+                    let mut rc4 = self.init_rc4(seed_key, function.size);
+                    let mut prev_ins = 0;
+                    for ins in instructions {
+                        *ins = self.encrypt_instruction(&mut rc4, *ins, prev_ins);
+                        prev_ins = *ins;
+                    }
+                }
+            }
+        }
+        for range in &decrypt_result.encrypted_ranges {
+            let start_offset = (range.start_address - options.base_address) as usize / 4;
+            let end_offset = (range.end_address - options.base_address) as usize / 4;
+            let instructions = words.get_mut(start_offset..end_offset).ok_or_else(|| {
+                RangeOutOfBoundsSnafu {
+                    what: "range to encrypt",
+                    start: range.start_address,
+                    end: range.end_address,
+                    base_address: options.base_address,
+                    end_address: options.end_address,
+                }
+                .build()
+            })?;
+            let mut rc4 = self.init_rc4(range.seed_key, range.end_address - range.start_address);
+            let mut prev_ins = 0;
+            for ins in instructions {
+                *ins = self.encrypt_instruction(&mut rc4, *ins, prev_ins);
+                prev_ins = *ins;
+            }
+        }
+
+        Ok(())
     }
 
     fn find_bss_variable(&self, words: &[u32], options: &AlgoDecryptOptions) -> Result<u32, DsProtError> {
@@ -1085,6 +1247,7 @@ pub struct DsProtAlgoV6 {
     reference_offset: u32,
     unkeyed_encryption_xor: u32,
     precalculated_seed_key: u32,
+    decrypt_opcode: fn(curr: u8, prev: u8) -> u8,
     encrypt_opcode: fn(curr: u8, prev: u8) -> u8,
 }
 
@@ -1114,6 +1277,11 @@ impl DsProtAlgo for DsProtAlgoV1 {
         u32::from_le_bytes([rc4.decrypt_byte(bytes[0]), rc4.decrypt_byte(bytes[1]), bytes[2] ^ 0x01, bytes[3]])
     }
 
+    fn encrypt_instruction(&self, rc4: &mut Rc4, ins: u32, _prev_ins: u32) -> u32 {
+        let bytes = ins.to_le_bytes();
+        u32::from_le_bytes([rc4.encrypt_byte(bytes[0]), rc4.encrypt_byte(bytes[1]), bytes[2] ^ 0x01, bytes[3]])
+    }
+
     fn precalculated_seed_key(&self) -> Option<u32> {
         None
     }
@@ -1123,7 +1291,7 @@ impl DsProtAlgo for DsProtAlgoV1 {
         Rc4::new(&expanded_key, None)
     }
 
-    fn decrypt(&self, words: &mut [u32], options: &AlgoDecryptOptions) -> Result<DsProtDecryptDetails, DsProtError> {
+    fn decrypt(&self, words: &mut [u32], options: &AlgoDecryptOptions) -> Result<DsProtDecryptResult, DsProtError> {
         let AlgoDecryptOptions { base_address, version, .. } = *options;
 
         // Find the starts and keys of all encrypted code ranges
@@ -1133,22 +1301,22 @@ impl DsProtAlgo for DsProtAlgoV1 {
             .filter(|(_i, word)| [word[0], word[1], word[2], word[4], word[5]] == self.encrypted_range_start_signature)
             .map(|(i, word)| {
                 let start_address = base_address + i as u32 * 4 + 0x1c;
-                let key = word[6];
-                (start_address, key)
+                let seed_key = word[6];
+                (start_address, seed_key)
             })
             .collect();
 
         let mut encrypted_ranges = Vec::new();
-        for (start_address, key) in encrypted_range_starts {
-            log::debug!("Found encrypted range starting at {:#010x} with key {:#010x}", start_address, key);
+        for (start_address, seed_key) in encrypted_range_starts {
+            log::debug!("Found encrypted range starting at {:#010x} with key {:#010x}", start_address, seed_key);
 
-            let mut rc4 = self.init_rc4(key, 0); // function size not needed
+            let mut rc4 = self.init_rc4(seed_key, 0); // function size not needed
 
             for address in (start_address..).step_by(4) {
                 let offset = ((address - base_address) / 4) as usize;
                 let instruction = words[offset];
-                if instruction == key {
-                    encrypted_ranges.push(EncryptedRange { start_address, end_address: address });
+                if instruction == seed_key {
+                    encrypted_ranges.push(EncryptedRange { start_address, end_address: address, seed_key });
                     break;
                 }
                 let prev_ins = 0; // unused
@@ -1157,7 +1325,13 @@ impl DsProtAlgo for DsProtAlgoV1 {
         }
         encrypted_ranges.sort_unstable_by_key(|r| r.start_address);
 
-        Ok(DsProtDecryptDetails::Pre1_23 { version, encrypted_ranges })
+        Ok(DsProtDecryptResult {
+            version,
+            encrypted_ranges,
+            bss_variable: None,
+            encrypted_functions: Vec::new(),
+            encoded_function_pointers: Vec::new(),
+        })
     }
 }
 
@@ -1176,8 +1350,8 @@ impl DsProtAlgo for DsProtAlgoV2 {
 
     fn unkeyed_encrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32) {
         let new_ins = match InstructionCategory::new(ins) {
-            InstructionCategory::BlxImm | InstructionCategory::Bl => encrypt_branch_1(self.reference_offset, ins),
-            InstructionCategory::B => encrypt_branch_2(self.reference_offset, ins),
+            InstructionCategory::BlxImm | InstructionCategory::Bl => encrypt_branch_2(self.reference_offset, ins),
+            InstructionCategory::B => encrypt_branch_1(self.reference_offset, ins),
             InstructionCategory::Other => ins ^ xor,
         };
         (new_ins, xor)
@@ -1199,6 +1373,17 @@ impl DsProtAlgo for DsProtAlgoV2 {
             InstructionCategory::Other => {
                 let bytes = ins.to_le_bytes();
                 u32::from_le_bytes([rc4.decrypt_byte(bytes[0]), rc4.decrypt_byte(bytes[1]), bytes[2] ^ 1, bytes[3]])
+            }
+        }
+    }
+
+    fn encrypt_instruction(&self, rc4: &mut Rc4, ins: u32, _prev_ins: u32) -> u32 {
+        match InstructionCategory::new(ins) {
+            InstructionCategory::BlxImm | InstructionCategory::Bl => encrypt_branch_2(self.reference_offset, ins),
+            InstructionCategory::B => encrypt_branch_1(self.reference_offset, ins),
+            InstructionCategory::Other => {
+                let bytes = ins.to_le_bytes();
+                u32::from_le_bytes([rc4.encrypt_byte(bytes[0]), rc4.encrypt_byte(bytes[1]), bytes[2] ^ 1, bytes[3]])
             }
         }
     }
@@ -1228,11 +1413,11 @@ impl DsProtAlgo for DsProtAlgoV3 {
 
     fn unkeyed_encrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32) {
         match InstructionCategory::new(ins) {
-            InstructionCategory::BlxImm | InstructionCategory::B => {
-                let new_ins = decrypt_branch_2(self.reference_offset, ins);
+            InstructionCategory::BlxImm | InstructionCategory::Bl => {
+                let new_ins = encrypt_branch_2(self.reference_offset, ins);
                 (new_ins, xor)
             }
-            InstructionCategory::Bl => {
+            InstructionCategory::B => {
                 let new_ins = ins ^ xor ^ 0x01000000; // flip link bit
                 (new_ins, (xor << 1).wrapping_add(ins) & 0xffffff)
             }
@@ -1279,6 +1464,25 @@ impl DsProtAlgo for DsProtAlgoV3 {
         }
     }
 
+    fn encrypt_instruction(&self, rc4: &mut Rc4, ins: u32, _prev_ins: u32) -> u32 {
+        match InstructionCategory::new(ins) {
+            InstructionCategory::BlxImm | InstructionCategory::Bl => encrypt_branch_2(self.reference_offset, ins),
+            category => {
+                let bytes = ins.to_le_bytes();
+                u32::from_le_bytes([
+                    rc4.encrypt_byte(bytes[0]),
+                    rc4.encrypt_byte(bytes[1]),
+                    bytes[2] ^ 0x3f,
+                    if category == InstructionCategory::B {
+                        bytes[3] ^ 0x01 // flip link bit
+                    } else {
+                        bytes[3]
+                    },
+                ])
+            }
+        }
+    }
+
     fn precalculated_seed_key(&self) -> Option<u32> {
         None
     }
@@ -1304,11 +1508,11 @@ impl DsProtAlgo for DsProtAlgoV4 {
 
     fn unkeyed_encrypt_instruction(&self, ins: u32, xor: u32) -> (u32, u32) {
         match InstructionCategory::new(ins) {
-            InstructionCategory::BlxImm | InstructionCategory::B => {
-                let new_ins = decrypt_branch_2(self.reference_offset, ins);
+            InstructionCategory::BlxImm | InstructionCategory::Bl => {
+                let new_ins = encrypt_branch_2(self.reference_offset, ins);
                 (new_ins, (xor ^ (ins >> 24)) & 0xffffff)
             }
-            InstructionCategory::Bl => {
+            InstructionCategory::B => {
                 let new_ins = ins ^ xor ^ 0x01000000; // flip link bit
                 (new_ins, (xor ^ ins ^ (ins >> 8)) & 0xffffff)
             }
@@ -1355,6 +1559,32 @@ impl DsProtAlgo for DsProtAlgoV4 {
                     },
                 ]);
                 rc4.update_x(|x| bytes[2].wrapping_mul(x).wrapping_sub(bytes[3]));
+                result
+            }
+        }
+    }
+
+    fn encrypt_instruction(&self, rc4: &mut Rc4, ins: u32, _prev_ins: u32) -> u32 {
+        match InstructionCategory::new(ins) {
+            InstructionCategory::BlxImm | InstructionCategory::Bl => {
+                let new_ins = encrypt_branch_2(self.reference_offset, ins);
+                rc4.update_x(|x| x.wrapping_add((new_ins >> 24) as u8));
+                new_ins
+            }
+            category => {
+                let bytes = ins.to_le_bytes();
+                let new_bytes = [
+                    rc4.encrypt_byte(bytes[0]),
+                    rc4.encrypt_byte(bytes[1]),
+                    bytes[2] ^ 0xff,
+                    if category == InstructionCategory::B {
+                        bytes[3] ^ 0x01 // flip link bit
+                    } else {
+                        bytes[3]
+                    },
+                ];
+                let result = u32::from_le_bytes(new_bytes);
+                rc4.update_x(|x| new_bytes[2].wrapping_mul(x).wrapping_sub(new_bytes[3]));
                 result
             }
         }
@@ -1419,6 +1649,32 @@ impl DsProtAlgo for DsProtAlgoV5 {
         }
     }
 
+    fn encrypt_instruction(&self, rc4: &mut Rc4, ins: u32, _prev_ins: u32) -> u32 {
+        match InstructionCategory::new(ins) {
+            InstructionCategory::BlxImm | InstructionCategory::Bl => {
+                let new_ins = encrypt_branch_2(self.reference_offset, ins);
+                rc4.update_x(|x| x.wrapping_add((new_ins >> 24) as u8));
+                new_ins
+            }
+            category => {
+                let bytes = ins.to_le_bytes();
+                let new_bytes = [
+                    rc4.encrypt_byte(bytes[0]),
+                    rc4.encrypt_byte(bytes[1]),
+                    rc4.encrypt_byte(bytes[2]),
+                    if category == InstructionCategory::B {
+                        bytes[3] ^ 0x01 // flip link bit
+                    } else {
+                        bytes[3]
+                    },
+                ];
+                let result = u32::from_le_bytes(new_bytes);
+                rc4.update_x(|x| x.wrapping_sub(new_bytes[3]));
+                result
+            }
+        }
+    }
+
     fn precalculated_seed_key(&self) -> Option<u32> {
         None
     }
@@ -1457,7 +1713,7 @@ impl DsProtAlgo for DsProtAlgoV6 {
     fn decrypt_instruction(&self, rc4: &mut Rc4, ins: u32, prev_ins: u32) -> u32 {
         let opcode = (ins >> 24) as u8;
         let prev_opcode = (prev_ins >> 24) as u8;
-        let new_opcode = (self.encrypt_opcode)(opcode, prev_opcode);
+        let new_opcode = (self.decrypt_opcode)(opcode, prev_opcode);
         let ins = (ins & 0xffffff) | ((new_opcode as u32) << 24);
         let category = InstructionCategory::new(ins);
         let new_ins = match category {
@@ -1480,6 +1736,33 @@ impl DsProtAlgo for DsProtAlgoV6 {
         }
     }
 
+    fn encrypt_instruction(&self, rc4: &mut Rc4, ins: u32, prev_ins: u32) -> u32 {
+        let category = InstructionCategory::new(ins);
+        let new_ins = match category {
+            InstructionCategory::BlxImm | InstructionCategory::Bl => encrypt_branch_2(self.reference_offset, ins),
+            InstructionCategory::B | InstructionCategory::Other => {
+                let bytes = ins.to_le_bytes();
+                u32::from_le_bytes([
+                    rc4.encrypt_byte(bytes[0]),
+                    rc4.encrypt_byte(bytes[1]),
+                    rc4.encrypt_byte(bytes[2]),
+                    bytes[3],
+                ])
+            }
+        };
+        let new_ins = match category {
+            // flip link bit
+            InstructionCategory::BlxImm | InstructionCategory::B => new_ins ^ 0x01000000,
+            InstructionCategory::Bl | InstructionCategory::Other => new_ins,
+        };
+        let opcode = (new_ins >> 24) as u8;
+        let prev_opcode = (prev_ins >> 24) as u8;
+        let new_opcode = (self.encrypt_opcode)(opcode, prev_opcode);
+        let new_ins = (new_ins & 0xffffff) | ((new_opcode as u32) << 24);
+        rc4.update_x(|x| x.wrapping_sub(new_opcode));
+        new_ins
+    }
+
     fn precalculated_seed_key(&self) -> Option<u32> {
         Some(self.precalculated_seed_key)
     }
@@ -1490,79 +1773,89 @@ impl DsProtAlgo for DsProtAlgoV6 {
     }
 }
 
-/// Contains complete information about how DS Protect's encrypted code was decrypted.
-#[derive(Serialize, Deserialize)]
-pub enum DsProtDecryptDetails {
-    /// Before DS Protect version 1.23
-    Pre1_23 {
-        /// The DS Protect version number.
-        version: &'static str,
-        /// List of encrypted ranges of instructions.
-        encrypted_ranges: Vec<EncryptedRange>,
-    },
-    /// DS Protect version 1.23 and onwards
-    Post1_23 {
-        /// The DS Protect version number.
-        version: &'static str,
-        /// Address of the DS Protect BSS variable. Used for offsetting constants.
-        dsprot_bss: u32,
-        /// List of encrypted functions.
-        encrypted_functions: Vec<EncryptedFunction>,
-        /// List of encoded function pointers.
-        encoded_function_pointers: Vec<EncodedFunctionPointer>,
-    },
+/// Contains the result of decrypting DS Protect code.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub struct DsProtDecryptResult {
+    /// The version of DS Protect that was used.
+    pub version: DsProtVersionNumber,
+    /// List of encrypted ranges of instructions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub encrypted_ranges: Vec<EncryptedRange>,
+    /// Address of the DS Protect BSS variable. Used for offsetting constants.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bss_variable: Option<u32>,
+    /// List of encrypted functions.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub encrypted_functions: Vec<EncryptedFunction>,
+    /// List of encoded function pointers.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub encoded_function_pointers: Vec<EncodedFunctionPointer>,
 }
 
-impl DsProtDecryptDetails {
-    /// Returns a [`DisplayDsProtDecryptDetails`] which implements [`Display`].
-    pub fn display(&self, indent: usize) -> DisplayDsProtDecryptDetails<'_> {
-        DisplayDsProtDecryptDetails { inner: self, indent }
+impl DsProtDecryptResult {
+    /// Returns a [`DisplayDsProtDecryptResult`] which implements [`Display`].
+    pub fn display(&self, indent: usize) -> DisplayDsProtDecryptResult<'_> {
+        DisplayDsProtDecryptResult { inner: self, indent }
+    }
+
+    pub(crate) fn encrypt(&self, data: &mut [u8], base_address: u32) -> Result<(), DsProtError> {
+        let Some(dsprot_version) = DSPROT_VERSIONS.iter().find(|v| v.number == self.version) else {
+            return Ok(());
+        };
+
+        let end_address = base_address + data.len() as u32;
+
+        // Make 32-bit chunks
+        let words: &mut [u32] = bytemuck::cast_slice_mut(data);
+
+        dsprot_version.algo.encrypt(words, self, &AlgoEncryptOptions { base_address, end_address })
     }
 }
 
-/// Can be used to display values inside [`DsProtDecryptDetails`].
-pub struct DisplayDsProtDecryptDetails<'a> {
-    inner: &'a DsProtDecryptDetails,
+/// Can be used to display values inside [`DsProtDecryptResult`].
+pub struct DisplayDsProtDecryptResult<'a> {
+    inner: &'a DsProtDecryptResult,
     indent: usize,
 }
 
-impl Display for DisplayDsProtDecryptDetails<'_> {
+impl Display for DisplayDsProtDecryptResult<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         let i = " ".repeat(self.indent);
         let inner = self.inner;
-        match inner {
-            DsProtDecryptDetails::Pre1_23 { version, encrypted_ranges } => {
-                writeln!(f, "{i}Version ........... : {}", version)?;
-                writeln!(f, "{i}Encrypted ranges .. :")?;
-                for range in encrypted_ranges {
-                    writeln!(f, "{i}  {:#010x}..{:#010x}", range.start_address, range.end_address)?;
-                }
+        writeln!(f, "{i}Version .................... : {}", inner.version)?;
+        if !inner.encrypted_ranges.is_empty() {
+            writeln!(f, "{i}Encrypted ranges ........... :")?;
+            for range in &inner.encrypted_ranges {
+                writeln!(f, "{i}  {:#010x}..{:#010x}", range.start_address, range.end_address)?;
             }
-            DsProtDecryptDetails::Post1_23 { version, dsprot_bss, encrypted_functions, encoded_function_pointers } => {
-                writeln!(f, "{i}Version .................... : {}", version)?;
-                writeln!(f, "{i}BSS variable ............... : {:#010x}", dsprot_bss)?;
-                writeln!(f, "{i}Encrypted functions ........ :")?;
-                for function in encrypted_functions {
-                    writeln!(f, "{i}  Address ................ : {:#010x}", function.address)?;
-                    writeln!(f, "{i}  Size ................... : {:#x}", function.size)?;
-                    write!(f, "{i}  Encryption ............. : ")?;
-                    match function.encryption {
-                        EncryptionType::None => {
-                            writeln!(f, "None")?;
-                        }
-                        EncryptionType::Unkeyed => {
-                            writeln!(f, "Unkeyed")?;
-                        }
-                        EncryptionType::Keyed(seed_key) => {
-                            writeln!(f, "Keyed ({:#x})", seed_key)?;
-                        }
+        }
+        if let Some(bss_variable) = inner.bss_variable {
+            writeln!(f, "{i}BSS variable ............... : {:#010x}", bss_variable)?;
+        }
+        if !inner.encrypted_functions.is_empty() {
+            writeln!(f, "{i}Encrypted functions ........ :")?;
+            for function in &inner.encrypted_functions {
+                writeln!(f, "{i}  Address ................ : {:#010x}", function.address)?;
+                writeln!(f, "{i}  Size ................... : {:#x}", function.size)?;
+                write!(f, "{i}  Encryption ............. : ")?;
+                match function.encryption {
+                    EncryptionType::None => {
+                        writeln!(f, "None")?;
                     }
-                    writeln!(f, "{i}  Encoded constant pool .. : {:?}\n", function.constant_pool)?;
+                    EncryptionType::Unkeyed => {
+                        writeln!(f, "Unkeyed")?;
+                    }
+                    EncryptionType::Keyed(seed_key) => {
+                        writeln!(f, "Keyed ({:#x})", seed_key)?;
+                    }
                 }
-                writeln!(f, "{i}Encoded function pointers .. :")?;
-                for fn_ptr in encoded_function_pointers {
-                    writeln!(f, "{i}  Address .. : {:#010x}", fn_ptr.0)?;
-                }
+                writeln!(f, "{i}  Encoded constant pool .. : {:?}\n", function.constant_pool)?;
+            }
+        }
+        if !inner.encoded_function_pointers.is_empty() {
+            writeln!(f, "{i}Encoded function pointers .. :")?;
+            for fn_ptr in &inner.encoded_function_pointers {
+                writeln!(f, "{i}  Address .. : {:#010x}", fn_ptr.0)?;
             }
         }
         Ok(())
@@ -1570,14 +1863,27 @@ impl Display for DisplayDsProtDecryptDetails<'_> {
 }
 
 /// Represents an address range of encrypted instructions.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct EncryptedRange {
     start_address: u32,
     end_address: u32,
+    seed_key: u32,
+}
+
+impl EncryptedRange {
+    /// Returns the start address of this [`EncryptedRange`].
+    pub fn start_address(&self) -> u32 {
+        self.start_address
+    }
+
+    /// Returns the end address of this [`EncryptedRange`].
+    pub fn end_address(&self) -> u32 {
+        self.end_address
+    }
 }
 
 /// Contains information about an encrypted function.
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct EncryptedFunction {
     address: u32,
     size: u32,
@@ -1585,14 +1891,39 @@ pub struct EncryptedFunction {
     constant_pool: EncodedConstantPool,
 }
 
+impl EncryptedFunction {
+    /// Returns the address of this [`EncryptedFunction`].
+    pub fn address(&self) -> u32 {
+        self.address
+    }
+
+    /// Returns the size of this [`EncryptedFunction`].
+    pub fn size(&self) -> u32 {
+        self.size
+    }
+
+    /// Returns the [`EncryptionType`] of this [`EncryptedFunction`].
+    pub fn encryption(&self) -> EncryptionType {
+        self.encryption
+    }
+
+    /// Returns the [`EncodedConstantPool`] of this [`EncryptedFunction`].
+    pub fn constant_pool(&self) -> EncodedConstantPool {
+        self.constant_pool
+    }
+}
+
 /// The type of encryption used on an [`EncryptedFunction`].
-#[derive(Clone, Copy, Serialize, Deserialize)]
+#[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub enum EncryptionType {
     /// No encryption, only encoded constant pool.
+    #[serde(rename = "none")]
     None,
     /// Unkeyed encryption using an XOR cipher.
+    #[serde(rename = "unkeyed")]
     Unkeyed,
     /// Keyed encryption using modified [`Rc4`].
+    #[serde(rename = "keyed")]
     Keyed(u32),
 }
 
@@ -1641,5 +1972,56 @@ pub enum EncodedConstantPool {
 
 /// Represents a function pointer in a data section, which was encoded by adding the reference
 /// offset value.
-#[derive(PartialEq, Eq, Clone, Copy, Serialize, Deserialize)]
+#[derive(PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Debug)]
 pub struct EncodedFunctionPointer(u32);
+
+/// Defines whether DS Protect is present in the ARM9 program or an ARM9 overlay, and whether it
+/// is currently encrypted.
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum DsProtState {
+    /// Not present.
+    None,
+    /// Present and unencrypted.
+    Unencrypted(DsProtDecryptResult),
+    /// Present and encrypted.
+    Encrypted(DsProtDecryptResult),
+}
+
+impl DsProtState {
+    /// Returns `true` if DS Protect is not present. Opposite of [`DsProtState::is_present`].
+    pub fn is_none(&self) -> bool {
+        match self {
+            DsProtState::None => true,
+            DsProtState::Unencrypted(_) | DsProtState::Encrypted(_) => false,
+        }
+    }
+
+    /// Returns `true` if DS Protect is present. Opposite of [`DsProtState::is_none`].
+    pub fn is_present(&self) -> bool {
+        !self.is_none()
+    }
+
+    /// Returns `true` if DS Protect is present and encrypted.
+    pub fn is_encrypted(&self) -> bool {
+        match self {
+            DsProtState::Encrypted(_) => true,
+            DsProtState::None | DsProtState::Unencrypted(_) => false,
+        }
+    }
+
+    /// Returns `true` if DS Protect is present and unencrypted.
+    pub fn is_unencrypted(&self) -> bool {
+        match self {
+            DsProtState::Unencrypted(_) => true,
+            DsProtState::None | DsProtState::Encrypted(_) => false,
+        }
+    }
+
+    /// Returns `Some` containing a [`DsProtDecryptResult`] if DS Protect is present.
+    pub fn as_option(&self) -> Option<&DsProtDecryptResult> {
+        match self {
+            DsProtState::None => None,
+            DsProtState::Unencrypted(result) | DsProtState::Encrypted(result) => Some(result),
+        }
+    }
+}

--- a/lib/src/crypto/dsprot.rs
+++ b/lib/src/crypto/dsprot.rs
@@ -446,22 +446,21 @@ trait DsProtAlgo {
 
     fn decrypt(&self, words: &mut [u32], options: &AlgoDecryptOptions) -> Result<DsProtDecryptResult, DsProtError> {
         let dsprot_bss = self.find_bss_variable(words, options)?;
-        let function_tables = self.find_obfuscated_function_tables(options, words)?;
+        let mut functions = self.find_obfuscated_function_tables(options, words)?;
         let mut relocations = Vec::new();
         let mut unkeyed_encrypted_functions =
-            self.decode_function_tables(options, words, dsprot_bss, &function_tables, &mut relocations)?;
+            self.decode_function_tables(options, words, dsprot_bss, &functions, &mut relocations)?;
         let mut keyed_encrypted_functions =
             self.unkeyed_decrypt_functions(options, words, dsprot_bss, &mut unkeyed_encrypted_functions, &mut relocations)?;
         self.decrypt_wrappers(options, words, &mut keyed_encrypted_functions, &mut relocations)?;
 
-        relocations.sort_unstable_by_key(|r| r.address);
-        relocations.dedup_by_key(|r| r.address);
+        relocations.sort_unstable_by_key(|r| r.from_address);
+        relocations.dedup_by_key(|r| r.from_address);
 
         if options.decode_relocations {
             self.decode_relocations(options, words, &relocations)?;
         }
 
-        let mut functions: Vec<DsProtFunction> = function_tables.into_iter().map(|(func, _)| func).collect();
         functions.append(&mut unkeyed_encrypted_functions);
         functions.append(&mut keyed_encrypted_functions);
         functions.sort_unstable_by_key(|f| f.address);
@@ -541,16 +540,17 @@ trait DsProtAlgo {
         // Encode relocations
         if options.encode_relocations {
             for relocation in &decrypt_result.relocations {
-                let Some(relocated_value) = words.get_mut((relocation.address - options.base_address) as usize / 4) else {
+                let Some(relocated_value) = words.get_mut((relocation.from_address - options.base_address) as usize / 4)
+                else {
                     return OutOfBoundsSnafu {
                         what: "relocation",
-                        address: relocation.address,
+                        address: relocation.from_address,
                         base_address: options.base_address,
                         end_address: options.end_address,
                     }
                     .fail();
                 };
-                *relocated_value += relocation.offset;
+                *relocated_value += relocation.addend;
             }
         }
 
@@ -612,7 +612,7 @@ trait DsProtAlgo {
         &self,
         options: &AlgoDecryptOptions,
         words: &[u32],
-    ) -> Result<Vec<(DsProtFunction, FunctionTable)>, DsProtError> {
+    ) -> Result<Vec<DsProtFunction>, DsProtError> {
         let AlgoDecryptOptions { base_address, .. } = *options;
 
         let mut function_tables = Vec::new();
@@ -695,18 +695,16 @@ trait DsProtAlgo {
                 return DecoderOverwriteAddressNotFoundSnafu { decoder_address: address - fn_offset }.fail();
             }
 
-            function_tables.push((
-                DsProtFunction {
-                    address: address - fn_offset,
-                    size: pool_offset + fn_offset,
-                    encryption: EncryptionType::None,
-                },
-                FunctionTable {
+            function_tables.push(DsProtFunction {
+                address: address - fn_offset,
+                size: pool_offset + fn_offset,
+                encryption: EncryptionType::None,
+                function_table: Some(FunctionTable {
                     length: (table_end_address - pool_address) / 8,
-                    with_garbage: garbage_address.is_some(),
-                    with_overwrite: overwrite_address.is_some(),
-                },
-            ));
+                    has_garbage: garbage_address.is_some(),
+                    has_overwrite: overwrite_address.is_some(),
+                }),
+            });
         }
 
         Ok(function_tables)
@@ -764,21 +762,35 @@ trait DsProtAlgo {
                 let garbage_address = pool_words[4] - reference_offset;
 
                 // Check that this looks like a RAM address
-                let with_garbage = garbage_address >> 24 == 0x02;
+                let has_garbage = garbage_address >> 24 == 0x02;
 
                 // BSS + 1
-                relocations.push(DsProtRelocation { address: function_end_address, offset: 1 });
+                relocations.push(DsProtRelocation { from_address: function_end_address, to_address: dsprot_bss, addend: 1 });
                 // Destination function size
-                relocations
-                    .push(DsProtRelocation { address: function_end_address + 0x4, offset: dest_func_size + reference_offset });
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address + 0x4,
+                    to_address: dsprot_bss,
+                    addend: dest_func_size + reference_offset,
+                });
                 // Seed key
-                relocations
-                    .push(DsProtRelocation { address: function_end_address + 0x8, offset: seed_key + reference_offset });
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address + 0x8,
+                    to_address: dsprot_bss,
+                    addend: seed_key + reference_offset,
+                });
                 // Destination function address
-                relocations.push(DsProtRelocation { address: function_end_address + 0xc, offset: reference_offset });
-                if with_garbage {
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address + 0xc,
+                    to_address: dest_func_address,
+                    addend: reference_offset,
+                });
+                if has_garbage {
                     // Pointer to garbage code
-                    relocations.push(DsProtRelocation { address: function_end_address + 0x10, offset: reference_offset });
+                    relocations.push(DsProtRelocation {
+                        from_address: function_end_address + 0x10,
+                        to_address: garbage_address,
+                        addend: reference_offset,
+                    });
                 }
 
                 log::debug!(
@@ -790,6 +802,7 @@ trait DsProtAlgo {
                     address: dest_func_address,
                     size: dest_func_size,
                     encryption: EncryptionType::Keyed(seed_key),
+                    function_table: None,
                 });
             } else if func_words.len() >= 4 && func_words[0..4] == DECRYPTION_WRAPPER_SIGNATURE_2 {
                 let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 7)?;
@@ -799,26 +812,45 @@ trait DsProtAlgo {
                 let seed_key = pool_words[1] - dsprot_bss - reference_offset;
                 let dest_func_address = pool_words[2] - reference_offset;
                 let dest_func_size = pool_words[3] - dsprot_bss - reference_offset;
+                let wrapper_fragment = pool_words[5] - reference_offset;
                 let garbage_address = pool_words[6] - reference_offset;
 
                 // Check that this looks like a RAM address
-                let with_garbage = garbage_address >> 24 == 0x02;
+                let has_garbage = garbage_address >> 24 == 0x02;
 
                 // BSS + 1
-                relocations.push(DsProtRelocation { address: function_end_address, offset: 1 });
+                relocations.push(DsProtRelocation { from_address: function_end_address, to_address: dsprot_bss, addend: 1 });
                 // Seed key
-                relocations
-                    .push(DsProtRelocation { address: function_end_address + 0x4, offset: seed_key + reference_offset });
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address + 0x4,
+                    to_address: dsprot_bss,
+                    addend: seed_key + reference_offset,
+                });
                 // Destination function address
-                relocations.push(DsProtRelocation { address: function_end_address + 0x8, offset: reference_offset });
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address + 0x8,
+                    to_address: dest_func_address,
+                    addend: reference_offset,
+                });
                 // Destination function size
-                relocations
-                    .push(DsProtRelocation { address: function_end_address + 0xc, offset: dest_func_size + reference_offset });
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address + 0xc,
+                    to_address: dsprot_bss,
+                    addend: dest_func_size + reference_offset,
+                });
                 // Decryption wrapper fragment address
-                relocations.push(DsProtRelocation { address: function_end_address + 0x14, offset: reference_offset });
-                if with_garbage {
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address + 0x14,
+                    to_address: wrapper_fragment,
+                    addend: reference_offset,
+                });
+                if has_garbage {
                     // Pointer to garbage code
-                    relocations.push(DsProtRelocation { address: function_end_address + 0x18, offset: reference_offset });
+                    relocations.push(DsProtRelocation {
+                        from_address: function_end_address + 0x18,
+                        to_address: garbage_address,
+                        addend: reference_offset,
+                    });
                 }
 
                 log::debug!(
@@ -830,6 +862,7 @@ trait DsProtAlgo {
                     address: dest_func_address,
                     size: dest_func_size,
                     encryption: EncryptionType::Keyed(seed_key),
+                    function_table: None,
                 });
             } else if func_words.len() >= 4
                 && (func_words[0..4] == DECRYPTION_WRAPPER_SIGNATURE_3 || func_words[0..4] == DECRYPTION_WRAPPER_SIGNATURE_4)
@@ -846,23 +879,41 @@ trait DsProtAlgo {
                 let wrapper_fragment_size = pool_words[5] >> 26;
 
                 // Check that this looks like a RAM address
-                let with_garbage = garbage_address >> 24 == 0x02;
+                let has_garbage = garbage_address >> 24 == 0x02;
 
                 // BSS + 1
-                relocations.push(DsProtRelocation { address: function_end_address, offset: 1 });
+                relocations.push(DsProtRelocation { from_address: function_end_address, to_address: dsprot_bss, addend: 1 });
                 // Seed key placeholder (BSS + 3 initially)
-                relocations.push(DsProtRelocation { address: function_end_address + 0x4, offset: 3 });
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address + 0x4,
+                    to_address: dsprot_bss,
+                    addend: 3,
+                });
                 // Destination function address
-                relocations.push(DsProtRelocation { address: function_end_address + 0x8, offset: reference_offset });
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address + 0x8,
+                    to_address: dest_func_address,
+                    addend: reference_offset,
+                });
                 // Destination function size
-                relocations
-                    .push(DsProtRelocation { address: function_end_address + 0xc, offset: dest_func_size + reference_offset });
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address + 0xc,
+                    to_address: dsprot_bss,
+                    addend: dest_func_size + reference_offset,
+                });
                 // Decryption wrapper fragment address
-                relocations
-                    .push(DsProtRelocation { address: function_end_address + 0x14, offset: pool_words[5] & 0xfc000000 });
-                if with_garbage {
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address + 0x14,
+                    to_address: wrapper_fragment,
+                    addend: pool_words[5] & 0xfc000000,
+                });
+                if has_garbage {
                     // Pointer to garbage code
-                    relocations.push(DsProtRelocation { address: function_end_address + 0x18, offset: reference_offset });
+                    relocations.push(DsProtRelocation {
+                        from_address: function_end_address + 0x18,
+                        to_address: garbage_address,
+                        addend: reference_offset,
+                    });
                 }
 
                 let seed_key = self.precalculated_seed_key().unwrap();
@@ -880,38 +931,40 @@ trait DsProtAlgo {
                     address: dest_func_address,
                     size: dest_func_size,
                     encryption: EncryptionType::Keyed(seed_key),
+                    function_table: None,
                 });
-            } else if func_words[0..4] == [0xe92d4070, 0xe24dd010, 0xe59f40ac, 0xe59fc0ac] {
+            } else if func_words.len() >= 4 && func_words[0..4] == [0xe92d4070, 0xe24dd010, 0xe59f40ac, 0xe59fc0ac] {
                 // Decryption proxy
                 let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 2)?;
-                relocations.push(DsProtRelocation { address: pool_words[1], offset: reference_offset });
+                relocations.push(proxy_relocation(pool_words[1], words, base_address, end_address, reference_offset)?);
                 log::debug!("Decrypted decryption proxy function");
-            } else if func_words[0..4] == [0xe92d41f0, 0xe24dd010, 0xe1a05000, 0xe59f00c0] {
+            } else if func_words.len() >= 4 && func_words[0..4] == [0xe92d41f0, 0xe24dd010, 0xe1a05000, 0xe59f00c0] {
                 // Encryption proxy
                 let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 1)?;
-                relocations.push(DsProtRelocation { address: pool_words[0], offset: reference_offset });
+                relocations.push(proxy_relocation(pool_words[0], words, base_address, end_address, reference_offset)?);
                 log::debug!("Decrypted encryption proxy function");
-            } else if func_words[0..4] == [0xe92d000f, 0xe58ca010, 0xe1a0a00c, 0xe59fc054] {
+            } else if func_words.len() >= 4 && func_words[0..4] == [0xe92d000f, 0xe58ca010, 0xe1a0a00c, 0xe59fc054] {
                 // Decryption wrapper proxy
                 let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 2)?;
-                relocations.push(DsProtRelocation { address: pool_words[0], offset: reference_offset });
-                relocations.push(DsProtRelocation { address: pool_words[1], offset: reference_offset });
+                relocations.push(proxy_relocation(pool_words[0], words, base_address, end_address, reference_offset)?);
+                relocations.push(proxy_relocation(pool_words[1], words, base_address, end_address, reference_offset)?);
                 log::debug!("Decrypted decryption wrapper proxy function");
-            } else if func_words[0..4] == [0xe92d4ff8, 0xe24dd008, 0xe1a0b003, 0xe1a0a000]
-                || func_words[0..4] == [0xe92d4ff8, 0xe24dd010, 0xe1a0a000, 0xe1a00003]
+            } else if func_words.len() >= 4
+                && (func_words[0..4] == [0xe92d4ff8, 0xe24dd008, 0xe1a0b003, 0xe1a0a000]
+                    || func_words[0..4] == [0xe92d4ff8, 0xe24dd010, 0xe1a0a000, 0xe1a00003])
             {
                 // RC4 encryptor/decryptor
                 let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 1)?;
-                relocations.push(DsProtRelocation { address: pool_words[0], offset: reference_offset });
-                relocations.push(DsProtRelocation { address: pool_words[0] + 0xc, offset: reference_offset });
+                relocations.push(proxy_relocation(pool_words[0], words, base_address, end_address, reference_offset)?);
+                relocations.push(proxy_relocation(pool_words[0] + 0xc, words, base_address, end_address, reference_offset)?);
                 log::debug!("Found RC4 encryptor/decryptor");
-            } else if func_words[0..4] == [0xe92d43f0, 0xe24ddf43, 0xe59f7064, 0xe28d8000] {
+            } else if func_words.len() >= 4 && func_words[0..4] == [0xe92d43f0, 0xe24ddf43, 0xe59f7064, 0xe28d8000] {
                 // RC4 encrypt/decrypt function
                 let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 1)?;
-                relocations.push(DsProtRelocation { address: pool_words[0], offset: reference_offset });
-                relocations.push(DsProtRelocation { address: pool_words[0] + 0x4, offset: reference_offset });
-                relocations.push(DsProtRelocation { address: pool_words[0] + 0x8, offset: reference_offset });
-                relocations.push(DsProtRelocation { address: pool_words[0] + 0x10, offset: reference_offset });
+                relocations.push(proxy_relocation(pool_words[0], words, base_address, end_address, reference_offset)?);
+                relocations.push(proxy_relocation(pool_words[0] + 0x4, words, base_address, end_address, reference_offset)?);
+                relocations.push(proxy_relocation(pool_words[0] + 0x8, words, base_address, end_address, reference_offset)?);
+                relocations.push(proxy_relocation(pool_words[0] + 0x10, words, base_address, end_address, reference_offset)?);
                 log::debug!("Found RC4 encrypt/decrypt function");
             }
         }
@@ -923,17 +976,18 @@ trait DsProtAlgo {
         options: &AlgoDecryptOptions,
         words: &mut [u32],
         dsprot_bss: u32,
-        function_tables: &[(DsProtFunction, FunctionTable)],
+        function_tables: &[DsProtFunction],
         relocations: &mut Vec<DsProtRelocation>,
     ) -> Result<Vec<DsProtFunction>, DsProtError> {
         let AlgoDecryptOptions { base_address, end_address, .. } = *options;
 
         let mut functions = Vec::new();
-        for (function, function_table) in function_tables {
-            let &DsProtFunction { address: func_address, size: func_size, encryption: _ } = function;
-            let &FunctionTable { length, with_garbage, with_overwrite } = function_table;
+        for function in function_tables {
+            let Some(FunctionTable { length, has_garbage, has_overwrite }) = function.function_table else {
+                continue;
+            };
 
-            let function_table_address = func_address + func_size;
+            let function_table_address = function.address + function.size;
 
             log::debug!("Obfuscated function table found at {:#010x}", function_table_address);
 
@@ -965,25 +1019,43 @@ trait DsProtAlgo {
                 log::debug!("Found unkeyed encrypted function at {:#010x}, size {:#x}", func_address, func_size);
 
                 // Function address
-                relocations
-                    .push(DsProtRelocation { address: function_table_address + i * 8, offset: self.reference_offset() });
+                relocations.push(DsProtRelocation {
+                    from_address: function_table_address + i * 8,
+                    to_address: func_address,
+                    addend: self.reference_offset(),
+                });
                 // Function size
                 relocations.push(DsProtRelocation {
-                    address: function_table_address + i * 8 + 4,
-                    offset: func_size + self.reference_offset(),
+                    from_address: function_table_address + i * 8 + 4,
+                    to_address: dsprot_bss,
+                    addend: func_size + self.reference_offset(),
                 });
 
-                functions.push(DsProtFunction { address: func_address, size: func_size, encryption: EncryptionType::Unkeyed });
+                functions.push(DsProtFunction {
+                    address: func_address,
+                    size: func_size,
+                    encryption: EncryptionType::Unkeyed,
+                    function_table: None,
+                });
             }
 
             let mut current_address = function_table_address + length * 8;
-            if with_garbage {
-                relocations.push(DsProtRelocation { address: current_address, offset: self.reference_offset() });
+            if has_garbage && let Some(pool_word) = pool_iter.next() {
+                let garbage_address = pool_word - self.reference_offset();
+                relocations.push(DsProtRelocation {
+                    from_address: current_address,
+                    to_address: garbage_address,
+                    addend: self.reference_offset(),
+                });
                 current_address += 4;
             }
-            if with_overwrite {
-                relocations.push(DsProtRelocation { address: current_address, offset: self.reference_offset() });
-                // current_address += 4;
+            if has_overwrite && let Some(pool_word) = pool_iter.next() {
+                let overwrite_address = pool_word - self.reference_offset();
+                relocations.push(DsProtRelocation {
+                    from_address: current_address,
+                    to_address: overwrite_address,
+                    addend: self.reference_offset(),
+                });
             }
         }
         Ok(functions)
@@ -1038,6 +1110,16 @@ trait DsProtAlgo {
             let limit = func_start.len().min(func_words.len());
             func_start[0..limit].copy_from_slice(&func_words[0..limit]);
 
+            let Some(pool_words) = words.get(func_end_offset..) else {
+                return OutOfBoundsSnafu {
+                    what: "encrypted function constant pool",
+                    address: function.address + function.size,
+                    base_address,
+                    end_address,
+                }
+                .fail();
+            };
+
             let reference_offset = self.reference_offset();
 
             if func_start[0..4] == [0xe92d4ff8, 0xe24dd080, 0xe59f209c, 0xe59f109c]
@@ -1047,54 +1129,114 @@ trait DsProtAlgo {
             {
                 log::debug!("Decrypted flashcart/emulator detector (type 1)");
 
-                // Test function address
-                relocations.push(DsProtRelocation { address: function_end_address, offset: reference_offset });
-                // Integrity function address
-                relocations.push(DsProtRelocation { address: function_end_address + 0x4, offset: reference_offset });
+                let test_fn_addr = pool_words[0] - reference_offset;
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address,
+                    to_address: test_fn_addr,
+                    addend: reference_offset,
+                });
+
+                let integrity_fn_addr = pool_words[1] - reference_offset;
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address + 0x4,
+                    to_address: integrity_fn_addr,
+                    addend: reference_offset,
+                });
             } else if func_start[0..4] == [0xe92d4ff8, 0xe24dd098, 0xe59f2170, 0xe59f4170]
                 || func_start[0..4] == [0xe92d4ff8, 0xe24dd098, 0xe59f2174, 0xe59f4174]
             {
                 log::debug!("Decrypted flashcart/emulator detector (type 2)");
 
-                // Callback index address
-                relocations.push(DsProtRelocation { address: function_end_address, offset: reference_offset });
-                // Callback table address
-                relocations.push(DsProtRelocation { address: function_end_address + 0x4, offset: reference_offset });
-                // Test function address
-                relocations.push(DsProtRelocation { address: function_end_address + 0x8, offset: reference_offset });
-                // Integrity function address
-                relocations.push(DsProtRelocation { address: function_end_address + 0xc, offset: reference_offset });
+                let callback_index_addr = pool_words[0] - reference_offset;
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address,
+                    to_address: callback_index_addr,
+                    addend: reference_offset,
+                });
+
+                let callback_table_addr = pool_words[1] - reference_offset;
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address + 0x4,
+                    to_address: callback_table_addr,
+                    addend: reference_offset,
+                });
+
+                let test_fn_addr = pool_words[2] - reference_offset;
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address + 0x8,
+                    to_address: test_fn_addr,
+                    addend: reference_offset,
+                });
+
+                let integrity_fn_addr = pool_words[3] - reference_offset;
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address + 0xc,
+                    to_address: integrity_fn_addr,
+                    addend: reference_offset,
+                });
             } else if func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f3070, 0xe3a02000]
                 || func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f3074, 0xe3a02000]
                 || func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f3080, 0xe3a02000]
             {
                 log::debug!("Decrypted dummy detector");
 
-                // Test function address
-                relocations.push(DsProtRelocation { address: function_end_address, offset: reference_offset });
+                let test_fn_addr = pool_words[0] - reference_offset;
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address,
+                    to_address: test_fn_addr,
+                    addend: reference_offset,
+                });
             } else if func_start[0..4] == [0xe92d4ff8, 0xe24dd018, 0xe59fa100, 0xe59f6100] {
                 log::debug!("Decrypted MAC and ROM integrity checkers");
 
-                // MAC integrity function address
-                relocations.push(DsProtRelocation { address: function_end_address, offset: reference_offset });
-                // MAC test function address
-                relocations.push(DsProtRelocation { address: function_end_address + 0x4, offset: reference_offset });
-                // ROM integrity function address
-                relocations.push(DsProtRelocation { address: function_end_address + 0x8, offset: reference_offset });
-                // ROM test function address
-                relocations.push(DsProtRelocation { address: function_end_address + 0xc, offset: reference_offset });
+                let mac_integrity_fn_addr = pool_words[0] - reference_offset;
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address,
+                    to_address: mac_integrity_fn_addr,
+                    addend: reference_offset,
+                });
+                let mac_test_fn_addr = pool_words[1] - reference_offset;
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address + 0x4,
+                    to_address: mac_test_fn_addr,
+                    addend: reference_offset,
+                });
+                let rom_integrity_fn_addr = pool_words[2] - reference_offset;
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address + 0x8,
+                    to_address: rom_integrity_fn_addr,
+                    addend: reference_offset,
+                });
+                let rom_test_fn_addr = pool_words[3] - reference_offset;
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address + 0xc,
+                    to_address: rom_test_fn_addr,
+                    addend: reference_offset,
+                });
             } else if func_start[6] == 0x112fff1e {
-                log::debug!("Decrypted integrity checker");
+                let checked_fn_addr = pool_words[0] - self.integrity_check_offset();
+                log::debug!("Decrypted integrity checker for {:#010x}", checked_fn_addr);
 
-                // Checked function address
-                relocations.push(DsProtRelocation { address: function_end_address, offset: self.integrity_check_offset() });
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address,
+                    to_address: checked_fn_addr,
+                    addend: self.integrity_check_offset(),
+                });
             } else if func_start[0..4] == [0xe1a0a00f, 0xe19aa00a, 0x102ee00e, 0xe25aa008] {
                 log::debug!("Decrypted crash function");
 
-                // Clear function address
-                relocations.push(DsProtRelocation { address: function_end_address, offset: reference_offset });
-                // Termination function address
-                relocations.push(DsProtRelocation { address: function_end_address + 0x4, offset: reference_offset });
+                let clear_fn_addr = pool_words[0] - reference_offset;
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address,
+                    to_address: clear_fn_addr,
+                    addend: reference_offset,
+                });
+                let terminate_fn_addr = pool_words[1] - reference_offset;
+                relocations.push(DsProtRelocation {
+                    from_address: function_end_address + 0x4,
+                    to_address: terminate_fn_addr,
+                    addend: reference_offset,
+                });
             }
             // The other function types don't have any encrypted constant pools
         }
@@ -1109,10 +1251,11 @@ trait DsProtAlgo {
     ) -> Result<(), DsProtError> {
         let &AlgoDecryptOptions { base_address, end_address, .. } = options;
         for relocation in relocations.iter() {
-            let Some(relocated_value) = words.get_mut((relocation.address - base_address) as usize / 4) else {
-                return OutOfBoundsSnafu { what: "relocation", address: relocation.address, base_address, end_address }.fail();
+            let Some(relocated_value) = words.get_mut((relocation.from_address - base_address) as usize / 4) else {
+                return OutOfBoundsSnafu { what: "relocation", address: relocation.from_address, base_address, end_address }
+                    .fail();
             };
-            *relocated_value -= relocation.offset;
+            *relocated_value -= relocation.addend;
         }
         Ok(())
     }
@@ -1139,6 +1282,21 @@ fn get_constant_pool(
         .fail();
     };
     Ok(pool_words)
+}
+
+fn proxy_relocation(
+    proxy_ptr_address: u32,
+    words: &[u32],
+    base_address: u32,
+    end_address: u32,
+    reference_offset: u32,
+) -> Result<DsProtRelocation, DsProtError> {
+    let offset = (proxy_ptr_address - base_address) as usize / 4;
+    let Some(proxy_fn) = words.get(offset) else {
+        return OutOfBoundsSnafu { what: "proxy function pointer", address: proxy_ptr_address, base_address, end_address }
+            .fail();
+    };
+    Ok(DsProtRelocation { from_address: proxy_ptr_address, to_address: proxy_fn - reference_offset, addend: reference_offset })
 }
 
 fn encrypt_branch_1(reference_offset: u32, ins: u32) -> u32 {
@@ -1337,7 +1495,7 @@ impl DsProtAlgo for DsProtAlgoV2 {
     }
 
     fn integrity_check_offset(&self) -> u32 {
-        self.reference_offset * 2
+        self.reference_offset
     }
 
     fn unkeyed_encryption_xor(&self) -> u32 {
@@ -1860,8 +2018,8 @@ impl Display for DisplayDsProtDecryptResult<'_> {
         if !inner.relocations.is_empty() {
             writeln!(f, "{i}Relocations ................ :")?;
             for fn_ptr in &inner.relocations {
-                writeln!(f, "{i}  Address .. : {:#010x}", fn_ptr.address)?;
-                writeln!(f, "{i}  Offset ... : {:#x}\n", fn_ptr.offset)?;
+                writeln!(f, "{i}  Address .. : {:#010x}", fn_ptr.from_address)?;
+                writeln!(f, "{i}  Offset ... : {:#x}\n", fn_ptr.addend)?;
             }
         }
         Ok(())
@@ -1871,9 +2029,12 @@ impl Display for DisplayDsProtDecryptResult<'_> {
 /// Represents an address range of encrypted instructions.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct EncryptedRange {
-    start_address: u32,
-    end_address: u32,
-    seed_key: u32,
+    /// Start of range, inclusive.
+    pub start_address: u32,
+    /// End of range, exclusive.
+    pub end_address: u32,
+    /// Seed key for RC4 keystream.
+    pub seed_key: u32,
 }
 
 impl EncryptedRange {
@@ -1891,26 +2052,15 @@ impl EncryptedRange {
 /// Contains information about a DS Protect function.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
 pub struct DsProtFunction {
-    address: u32,
-    size: u32,
-    encryption: EncryptionType,
-}
-
-impl DsProtFunction {
-    /// Returns the address of this [`DsProtFunction`].
-    pub fn address(&self) -> u32 {
-        self.address
-    }
-
-    /// Returns the size of this [`DsProtFunction`].
-    pub fn size(&self) -> u32 {
-        self.size
-    }
-
-    /// Returns the [`EncryptionType`] of this [`DsProtFunction`].
-    pub fn encryption(&self) -> EncryptionType {
-        self.encryption
-    }
+    /// This function's address.
+    pub address: u32,
+    /// This function's size, excluding constant pool.
+    pub size: u32,
+    /// The type of encryption applied to this function.
+    pub encryption: EncryptionType,
+    /// If this function is a decoder which performs unkeyed decryption on a list of functions, then
+    /// `function_table` will be `Some`.
+    pub function_table: Option<FunctionTable>,
 }
 
 /// The type of encryption used on a [`DsProtFunction`].
@@ -1927,21 +2077,27 @@ pub enum EncryptionType {
     Keyed(u32),
 }
 
-struct FunctionTable {
+/// Represents the size of the function table in the constant pool of a decoder function.
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
+pub struct FunctionTable {
     /// The number of (function address, function size) entries.
-    length: u32,
+    pub length: u32,
     /// If true, a pointer to DS Protect's garbage data was appended to the end of the constant pool.
-    with_garbage: bool,
+    pub has_garbage: bool,
     /// If true, a pointer to this decoder function was appended to the end of the constant pool.
-    with_overwrite: bool,
+    pub has_overwrite: bool,
 }
 
 /// Represents a pointer or constant in DS Protect's code which was encoded by adding an offset
 /// value to it.
 #[derive(PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Debug)]
 pub struct DsProtRelocation {
-    address: u32,
-    offset: u32,
+    /// The location of the relocated value.
+    pub from_address: u32,
+    /// The resolved address.
+    pub to_address: u32,
+    /// Offset to add to the resolved address.
+    pub addend: u32,
 }
 
 /// Defines whether DS Protect is present in the ARM9 program or an ARM9 overlay, and whether it

--- a/lib/src/crypto/dsprot.rs
+++ b/lib/src/crypto/dsprot.rs
@@ -310,16 +310,18 @@ pub enum DsProtError {
 
 /// Options for [`DsProtInfo::decrypt`].
 #[derive(Clone)]
-pub struct DecryptOptions {
+pub struct DsProtDecryptOptions {
     /// If true, pointers and constants will be decoded. This applies to constant pools and global
     /// variables managed by DS Protect.
-    ///
-    /// Pointers are decoded by subtracting the reference offset value based on the DS Protect
-    /// version.
-    ///
-    /// Constants are decoded by subtracting the reference offset and the address of an unused BSS
-    /// variable owned by DS Protect.
-    pub decode_literals: bool,
+    pub decode_relocations: bool,
+}
+
+/// Options for [`DsProtDecryptResult::encrypt`].
+#[derive(Clone)]
+pub struct DsProtEncryptOptions {
+    /// If true, pointers and constants will be decoded. This applies to constant pools and global
+    /// variables managed by DS Protect.
+    pub encode_relocations: bool,
 }
 
 impl DsProtInfo {
@@ -349,19 +351,19 @@ impl DsProtInfo {
         &self,
         data: &mut [u8],
         base_address: u32,
-        options: &DecryptOptions,
+        options: &DsProtDecryptOptions,
     ) -> Result<DsProtDecryptResult, DsProtError> {
         let end_address = base_address + data.len() as u32;
 
         // Make 32-bit chunks
         let words: &mut [u32] = bytemuck::cast_slice_mut(data);
 
-        let DecryptOptions { decode_literals } = options.clone();
+        let DsProtDecryptOptions { decode_relocations } = options.clone();
         self.version.algo.decrypt(words, &AlgoDecryptOptions {
             base_address,
             end_address,
             version: self.version.number,
-            decode_literals,
+            decode_relocations,
         })
     }
 
@@ -413,12 +415,13 @@ struct AlgoDecryptOptions {
     base_address: u32,
     end_address: u32,
     version: DsProtVersionNumber,
-    decode_literals: bool,
+    decode_relocations: bool,
 }
 
 struct AlgoEncryptOptions {
     base_address: u32,
     end_address: u32,
+    encode_relocations: bool,
 }
 
 const DECRYPTION_WRAPPER_SIGNATURE_1: [u32; 3] = [0xe92d00f0, 0xe92d000f, 0xe8bd00f0];
@@ -443,28 +446,32 @@ trait DsProtAlgo {
 
     fn decrypt(&self, words: &mut [u32], options: &AlgoDecryptOptions) -> Result<DsProtDecryptResult, DsProtError> {
         let dsprot_bss = self.find_bss_variable(words, options)?;
-        let obfuscated_function_tables = self.find_obfuscated_function_tables(options, words)?;
+        let function_tables = self.find_obfuscated_function_tables(options, words)?;
+        let mut relocations = Vec::new();
         let mut unkeyed_encrypted_functions =
-            self.decode_function_tables(options, words, dsprot_bss, &obfuscated_function_tables)?;
-        let (mut keyed_encrypted_functions, mut encoded_function_pointers) =
-            self.unkeyed_decrypt_functions(options, words, dsprot_bss, &mut unkeyed_encrypted_functions)?;
-        self.decrypt_wrappers(options, words, &mut keyed_encrypted_functions)?;
+            self.decode_function_tables(options, words, dsprot_bss, &function_tables, &mut relocations)?;
+        let mut keyed_encrypted_functions =
+            self.unkeyed_decrypt_functions(options, words, dsprot_bss, &mut unkeyed_encrypted_functions, &mut relocations)?;
+        self.decrypt_wrappers(options, words, &mut keyed_encrypted_functions, &mut relocations)?;
 
-        encoded_function_pointers.sort_unstable_by_key(|fp| fp.0);
-        encoded_function_pointers.dedup();
-        self.decode_function_pointers(options, words, &encoded_function_pointers)?;
+        relocations.sort_unstable_by_key(|r| r.address);
+        relocations.dedup_by_key(|r| r.address);
 
-        let mut encrypted_functions = obfuscated_function_tables;
-        encrypted_functions.append(&mut unkeyed_encrypted_functions);
-        encrypted_functions.append(&mut keyed_encrypted_functions);
-        encrypted_functions.sort_unstable_by_key(|f| f.address);
+        if options.decode_relocations {
+            self.decode_relocations(options, words, &relocations)?;
+        }
+
+        let mut functions: Vec<DsProtFunction> = function_tables.into_iter().map(|(func, _)| func).collect();
+        functions.append(&mut unkeyed_encrypted_functions);
+        functions.append(&mut keyed_encrypted_functions);
+        functions.sort_unstable_by_key(|f| f.address);
 
         Ok(DsProtDecryptResult {
             version: options.version,
             encrypted_ranges: Vec::new(),
             bss_variable: Some(dsprot_bss),
-            encrypted_functions,
-            encoded_function_pointers,
+            functions,
+            relocations,
         })
     }
 
@@ -474,7 +481,8 @@ trait DsProtAlgo {
         decrypt_result: &DsProtDecryptResult,
         options: &AlgoEncryptOptions,
     ) -> Result<(), DsProtError> {
-        for function in &decrypt_result.encrypted_functions {
+        // Encrypt whole functions
+        for function in &decrypt_result.functions {
             let start_offset = (function.address - options.base_address) as usize / 4;
             let end_offset = start_offset + function.size as usize / 4;
             let instructions = words.get_mut(start_offset..end_offset).ok_or_else(|| {
@@ -507,6 +515,8 @@ trait DsProtAlgo {
                 }
             }
         }
+
+        // Encrypt function ranges
         for range in &decrypt_result.encrypted_ranges {
             let start_offset = (range.start_address - options.base_address) as usize / 4;
             let end_offset = (range.end_address - options.base_address) as usize / 4;
@@ -525,6 +535,22 @@ trait DsProtAlgo {
             for ins in instructions {
                 *ins = self.encrypt_instruction(&mut rc4, *ins, prev_ins);
                 prev_ins = *ins;
+            }
+        }
+
+        // Encode relocations
+        if options.encode_relocations {
+            for relocation in &decrypt_result.relocations {
+                let Some(relocated_value) = words.get_mut((relocation.address - options.base_address) as usize / 4) else {
+                    return OutOfBoundsSnafu {
+                        what: "relocation",
+                        address: relocation.address,
+                        base_address: options.base_address,
+                        end_address: options.end_address,
+                    }
+                    .fail();
+                };
+                *relocated_value += relocation.offset;
             }
         }
 
@@ -586,10 +612,10 @@ trait DsProtAlgo {
         &self,
         options: &AlgoDecryptOptions,
         words: &[u32],
-    ) -> Result<Vec<EncryptedFunction>, DsProtError> {
+    ) -> Result<Vec<(DsProtFunction, FunctionTable)>, DsProtError> {
         let AlgoDecryptOptions { base_address, .. } = *options;
 
-        let mut encrypted_functions = Vec::new();
+        let mut function_tables = Vec::new();
         for (i, window) in words.windows(4).enumerate() {
             let address = base_address + i as u32 * 4;
             let (pool_offset, fn_offset, primary_decoder) =
@@ -669,19 +695,21 @@ trait DsProtAlgo {
                 return DecoderOverwriteAddressNotFoundSnafu { decoder_address: address - fn_offset }.fail();
             }
 
-            encrypted_functions.push(EncryptedFunction {
-                address: address - fn_offset,
-                size: pool_offset + fn_offset,
-                encryption: EncryptionType::None,
-                constant_pool: EncodedConstantPool::ObfuscatedFunctionTable {
+            function_tables.push((
+                DsProtFunction {
+                    address: address - fn_offset,
+                    size: pool_offset + fn_offset,
+                    encryption: EncryptionType::None,
+                },
+                FunctionTable {
                     length: (table_end_address - pool_address) / 8,
                     with_garbage: garbage_address.is_some(),
                     with_overwrite: overwrite_address.is_some(),
                 },
-            });
+            ));
         }
 
-        Ok(encrypted_functions)
+        Ok(function_tables)
     }
 
     fn unkeyed_decrypt_functions(
@@ -689,19 +717,20 @@ trait DsProtAlgo {
         options: &AlgoDecryptOptions,
         words: &mut [u32],
         dsprot_bss: u32,
-        unkeyed_encrypted_functions: &mut [EncryptedFunction],
-    ) -> Result<(Vec<EncryptedFunction>, Vec<EncodedFunctionPointer>), DsProtError> {
-        let AlgoDecryptOptions { base_address, end_address, decode_literals, .. } = *options;
+        unkeyed_encrypted_functions: &mut [DsProtFunction],
+        relocations: &mut Vec<DsProtRelocation>,
+    ) -> Result<Vec<DsProtFunction>, DsProtError> {
+        let AlgoDecryptOptions { base_address, end_address, .. } = *options;
 
         let mut decryption_wrappers = Vec::new();
-        let mut encoded_function_pointers = Vec::new();
         for function in unkeyed_encrypted_functions {
             let EncryptionType::Unkeyed = function.encryption else { continue };
 
             let func_offset = ((function.address - base_address) / 4) as usize;
-            let instruction_count = (function.size / 4) as usize;
+            let function_end_address = function.address + function.size;
+            let func_end_offset = ((function_end_address - base_address) / 4) as usize;
 
-            let Some(func_words) = words.get_mut(func_offset..func_offset + instruction_count) else {
+            let Some(func_words) = words.get_mut(func_offset..func_end_offset) else {
                 return RangeOutOfBoundsSnafu {
                     what: "unkeyed encrypted function",
                     start: function.address,
@@ -737,27 +766,30 @@ trait DsProtAlgo {
                 // Check that this looks like a RAM address
                 let with_garbage = garbage_address >> 24 == 0x02;
 
-                if decode_literals {
-                    pool_words[0] = bss;
-                    pool_words[1] = dest_func_size;
-                    pool_words[2] = seed_key;
-                    pool_words[3] = dest_func_address;
-                    if with_garbage {
-                        pool_words[4] = garbage_address;
-                    }
+                // BSS + 1
+                relocations.push(DsProtRelocation { address: function_end_address, offset: 1 });
+                // Destination function size
+                relocations
+                    .push(DsProtRelocation { address: function_end_address + 0x4, offset: dest_func_size + reference_offset });
+                // Seed key
+                relocations
+                    .push(DsProtRelocation { address: function_end_address + 0x8, offset: seed_key + reference_offset });
+                // Destination function address
+                relocations.push(DsProtRelocation { address: function_end_address + 0xc, offset: reference_offset });
+                if with_garbage {
+                    // Pointer to garbage code
+                    relocations.push(DsProtRelocation { address: function_end_address + 0x10, offset: reference_offset });
                 }
 
-                function.constant_pool = EncodedConstantPool::DecryptionWrapperType1 { with_garbage };
                 log::debug!(
                     "Found decryption wrapper (type 1) at {:#010x} which targets {:#010x}",
                     function.address,
                     dest_func_address
                 );
-                decryption_wrappers.push(EncryptedFunction {
+                decryption_wrappers.push(DsProtFunction {
                     address: dest_func_address,
                     size: dest_func_size,
                     encryption: EncryptionType::Keyed(seed_key),
-                    constant_pool: EncodedConstantPool::None,
                 });
             } else if func_words.len() >= 4 && func_words[0..4] == DECRYPTION_WRAPPER_SIGNATURE_2 {
                 let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 7)?;
@@ -767,34 +799,37 @@ trait DsProtAlgo {
                 let seed_key = pool_words[1] - dsprot_bss - reference_offset;
                 let dest_func_address = pool_words[2] - reference_offset;
                 let dest_func_size = pool_words[3] - dsprot_bss - reference_offset;
-                let wrapper_fragment = pool_words[5] - reference_offset;
                 let garbage_address = pool_words[6] - reference_offset;
 
                 // Check that this looks like a RAM address
                 let with_garbage = garbage_address >> 24 == 0x02;
 
-                if decode_literals {
-                    pool_words[0] = bss;
-                    pool_words[1] = seed_key;
-                    pool_words[2] = dest_func_address;
-                    pool_words[3] = dest_func_size;
-                    pool_words[5] = wrapper_fragment;
-                    if with_garbage {
-                        pool_words[6] = garbage_address;
-                    }
+                // BSS + 1
+                relocations.push(DsProtRelocation { address: function_end_address, offset: 1 });
+                // Seed key
+                relocations
+                    .push(DsProtRelocation { address: function_end_address + 0x4, offset: seed_key + reference_offset });
+                // Destination function address
+                relocations.push(DsProtRelocation { address: function_end_address + 0x8, offset: reference_offset });
+                // Destination function size
+                relocations
+                    .push(DsProtRelocation { address: function_end_address + 0xc, offset: dest_func_size + reference_offset });
+                // Decryption wrapper fragment address
+                relocations.push(DsProtRelocation { address: function_end_address + 0x14, offset: reference_offset });
+                if with_garbage {
+                    // Pointer to garbage code
+                    relocations.push(DsProtRelocation { address: function_end_address + 0x18, offset: reference_offset });
                 }
 
-                function.constant_pool = EncodedConstantPool::DecryptionWrapperType2 { with_garbage };
                 log::debug!(
                     "Found decryption wrapper (type 2) at {:#010x} which targets {:#010x}",
                     function.address,
                     dest_func_address
                 );
-                decryption_wrappers.push(EncryptedFunction {
+                decryption_wrappers.push(DsProtFunction {
                     address: dest_func_address,
                     size: dest_func_size,
                     encryption: EncryptionType::Keyed(seed_key),
-                    constant_pool: EncodedConstantPool::None,
                 });
             } else if func_words.len() >= 4
                 && (func_words[0..4] == DECRYPTION_WRAPPER_SIGNATURE_3 || func_words[0..4] == DECRYPTION_WRAPPER_SIGNATURE_4)
@@ -803,7 +838,6 @@ trait DsProtAlgo {
 
                 let bss = pool_words[0] - 1;
                 debug_assert_eq!(bss, dsprot_bss);
-                let seed_key_placeholder = pool_words[1] - 3;
                 let dest_func_address = pool_words[2] - reference_offset;
                 let dest_func_size = pool_words[3] - dsprot_bss - reference_offset;
                 let wrapper_fragment = pool_words[5] & 0x03ffffff;
@@ -814,20 +848,25 @@ trait DsProtAlgo {
                 // Check that this looks like a RAM address
                 let with_garbage = garbage_address >> 24 == 0x02;
 
-                if decode_literals {
-                    pool_words[0] = bss;
-                    pool_words[1] = seed_key_placeholder;
-                    pool_words[2] = dest_func_address;
-                    pool_words[3] = dest_func_size;
-                    pool_words[5] = wrapper_fragment;
-                    if with_garbage {
-                        pool_words[6] = garbage_address;
-                    }
+                // BSS + 1
+                relocations.push(DsProtRelocation { address: function_end_address, offset: 1 });
+                // Seed key placeholder (BSS + 3 initially)
+                relocations.push(DsProtRelocation { address: function_end_address + 0x4, offset: 3 });
+                // Destination function address
+                relocations.push(DsProtRelocation { address: function_end_address + 0x8, offset: reference_offset });
+                // Destination function size
+                relocations
+                    .push(DsProtRelocation { address: function_end_address + 0xc, offset: dest_func_size + reference_offset });
+                // Decryption wrapper fragment address
+                relocations
+                    .push(DsProtRelocation { address: function_end_address + 0x14, offset: pool_words[5] & 0xfc000000 });
+                if with_garbage {
+                    // Pointer to garbage code
+                    relocations.push(DsProtRelocation { address: function_end_address + 0x18, offset: reference_offset });
                 }
 
                 let seed_key = self.precalculated_seed_key().unwrap();
 
-                function.constant_pool = EncodedConstantPool::DecryptionWrapperType3 { with_garbage };
                 log::debug!(
                     "Found decryption wrapper (type 3) at {:#010x} which targets {:#010x}. \
                     Seed key {:#010x} was derived from function at {:#010x} with size {:#x}",
@@ -837,47 +876,46 @@ trait DsProtAlgo {
                     wrapper_fragment,
                     wrapper_fragment_size * 4,
                 );
-                decryption_wrappers.push(EncryptedFunction {
+                decryption_wrappers.push(DsProtFunction {
                     address: dest_func_address,
                     size: dest_func_size,
                     encryption: EncryptionType::Keyed(seed_key),
-                    constant_pool: EncodedConstantPool::None,
                 });
             } else if func_words[0..4] == [0xe92d4070, 0xe24dd010, 0xe59f40ac, 0xe59fc0ac] {
                 // Decryption proxy
                 let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 2)?;
-                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[1]));
+                relocations.push(DsProtRelocation { address: pool_words[1], offset: reference_offset });
                 log::debug!("Decrypted decryption proxy function");
             } else if func_words[0..4] == [0xe92d41f0, 0xe24dd010, 0xe1a05000, 0xe59f00c0] {
                 // Encryption proxy
                 let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 1)?;
-                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[0]));
+                relocations.push(DsProtRelocation { address: pool_words[0], offset: reference_offset });
                 log::debug!("Decrypted encryption proxy function");
             } else if func_words[0..4] == [0xe92d000f, 0xe58ca010, 0xe1a0a00c, 0xe59fc054] {
                 // Decryption wrapper proxy
                 let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 2)?;
-                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[0]));
-                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[1]));
+                relocations.push(DsProtRelocation { address: pool_words[0], offset: reference_offset });
+                relocations.push(DsProtRelocation { address: pool_words[1], offset: reference_offset });
                 log::debug!("Decrypted decryption wrapper proxy function");
             } else if func_words[0..4] == [0xe92d4ff8, 0xe24dd008, 0xe1a0b003, 0xe1a0a000]
                 || func_words[0..4] == [0xe92d4ff8, 0xe24dd010, 0xe1a0a000, 0xe1a00003]
             {
                 // RC4 encryptor/decryptor
                 let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 1)?;
-                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[0]));
-                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[0] + 0xc));
+                relocations.push(DsProtRelocation { address: pool_words[0], offset: reference_offset });
+                relocations.push(DsProtRelocation { address: pool_words[0] + 0xc, offset: reference_offset });
                 log::debug!("Found RC4 encryptor/decryptor");
             } else if func_words[0..4] == [0xe92d43f0, 0xe24ddf43, 0xe59f7064, 0xe28d8000] {
                 // RC4 encrypt/decrypt function
                 let pool_words = get_constant_pool(base_address, end_address, words, function.address, function.size, 1)?;
-                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[0]));
-                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[0] + 0x4));
-                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[0] + 0x8));
-                encoded_function_pointers.push(EncodedFunctionPointer(pool_words[0] + 0x10));
+                relocations.push(DsProtRelocation { address: pool_words[0], offset: reference_offset });
+                relocations.push(DsProtRelocation { address: pool_words[0] + 0x4, offset: reference_offset });
+                relocations.push(DsProtRelocation { address: pool_words[0] + 0x8, offset: reference_offset });
+                relocations.push(DsProtRelocation { address: pool_words[0] + 0x10, offset: reference_offset });
                 log::debug!("Found RC4 encrypt/decrypt function");
             }
         }
-        Ok((decryption_wrappers, encoded_function_pointers))
+        Ok(decryption_wrappers)
     }
 
     fn decode_function_tables(
@@ -885,17 +923,15 @@ trait DsProtAlgo {
         options: &AlgoDecryptOptions,
         words: &mut [u32],
         dsprot_bss: u32,
-        obfuscated_function_tables: &[EncryptedFunction],
-    ) -> Result<Vec<EncryptedFunction>, DsProtError> {
-        let AlgoDecryptOptions { base_address, end_address, decode_literals, .. } = *options;
+        function_tables: &[(DsProtFunction, FunctionTable)],
+        relocations: &mut Vec<DsProtRelocation>,
+    ) -> Result<Vec<DsProtFunction>, DsProtError> {
+        let AlgoDecryptOptions { base_address, end_address, .. } = *options;
 
-        let mut encrypted_functions = Vec::new();
-        for &EncryptedFunction { address: func_address, size: func_size, encryption: _, constant_pool } in
-            obfuscated_function_tables
-        {
-            let EncodedConstantPool::ObfuscatedFunctionTable { length, with_garbage, with_overwrite } = constant_pool else {
-                continue;
-            };
+        let mut functions = Vec::new();
+        for (function, function_table) in function_tables {
+            let &DsProtFunction { address: func_address, size: func_size, encryption: _ } = function;
+            let &FunctionTable { length, with_garbage, with_overwrite } = function_table;
 
             let function_table_address = func_address + func_size;
 
@@ -912,8 +948,8 @@ trait DsProtAlgo {
                 .fail();
             };
 
-            let mut pool_iter = pool_words.iter_mut();
-            for _ in 0..length {
+            let mut pool_iter = pool_words.iter();
+            for i in 0..length {
                 let Some(first) = pool_iter.next() else {
                     break;
                 };
@@ -928,42 +964,39 @@ trait DsProtAlgo {
                 let func_size = *second - dsprot_bss - self.reference_offset();
                 log::debug!("Found unkeyed encrypted function at {:#010x}, size {:#x}", func_address, func_size);
 
-                if decode_literals {
-                    *first = func_address;
-                    *second = func_size;
-                }
-
-                encrypted_functions.push(EncryptedFunction {
-                    address: func_address,
-                    size: func_size,
-                    encryption: EncryptionType::Unkeyed,
-                    constant_pool: EncodedConstantPool::None,
+                // Function address
+                relocations
+                    .push(DsProtRelocation { address: function_table_address + i * 8, offset: self.reference_offset() });
+                // Function size
+                relocations.push(DsProtRelocation {
+                    address: function_table_address + i * 8 + 4,
+                    offset: func_size + self.reference_offset(),
                 });
+
+                functions.push(DsProtFunction { address: func_address, size: func_size, encryption: EncryptionType::Unkeyed });
             }
 
-            if decode_literals {
-                // Decode pointer to garbage data
-                if with_garbage && let Some(next_chunk) = pool_iter.next() {
-                    *next_chunk -= self.reference_offset();
-                    log::debug!("Decoded garbage pointer after decoder function at {:#010x}", func_address);
-                }
-                // Decode pointer to this decoder function
-                if with_overwrite && let Some(next_chunk) = pool_iter.next() {
-                    *next_chunk -= self.reference_offset();
-                    log::debug!("Decoded overwrite pointer after decoder function at {:#010x}", func_address);
-                }
+            let mut current_address = function_table_address + length * 8;
+            if with_garbage {
+                relocations.push(DsProtRelocation { address: current_address, offset: self.reference_offset() });
+                current_address += 4;
+            }
+            if with_overwrite {
+                relocations.push(DsProtRelocation { address: current_address, offset: self.reference_offset() });
+                // current_address += 4;
             }
         }
-        Ok(encrypted_functions)
+        Ok(functions)
     }
 
     fn decrypt_wrappers(
         &self,
         options: &AlgoDecryptOptions,
         words: &mut [u32],
-        decryption_wrappers: &mut [EncryptedFunction],
+        decryption_wrappers: &mut [DsProtFunction],
+        relocations: &mut Vec<DsProtRelocation>,
     ) -> Result<(), DsProtError> {
-        let AlgoDecryptOptions { base_address, end_address, decode_literals, .. } = *options;
+        let AlgoDecryptOptions { base_address, end_address, .. } = *options;
 
         for function in decryption_wrappers {
             let EncryptionType::Keyed(seed_key) = function.encryption else {
@@ -981,7 +1014,8 @@ trait DsProtAlgo {
 
             // Decrypt instructions
             let func_offset = ((function.address - base_address) / 4) as usize;
-            let func_end_offset = func_offset + (function.size / 4) as usize;
+            let function_end_address = function.address + function.size;
+            let func_end_offset = ((function_end_address - base_address) / 4) as usize;
             let Some(func_words) = words.get_mut(func_offset..func_end_offset) else {
                 return RangeOutOfBoundsSnafu {
                     what: "encrypted function",
@@ -1004,16 +1038,6 @@ trait DsProtAlgo {
             let limit = func_start.len().min(func_words.len());
             func_start[0..limit].copy_from_slice(&func_words[0..limit]);
 
-            let Some(pool_words) = words.get_mut(func_end_offset..) else {
-                return OutOfBoundsSnafu {
-                    what: "encrypted function constant pool",
-                    address: function.address + function.size,
-                    base_address,
-                    end_address,
-                }
-                .fail();
-            };
-
             let reference_offset = self.reference_offset();
 
             if func_start[0..4] == [0xe92d4ff8, 0xe24dd080, 0xe59f209c, 0xe59f109c]
@@ -1021,102 +1045,74 @@ trait DsProtAlgo {
                 || func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f308c, 0xe59f208c]
                 || func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f307c, 0xe59f207c]
             {
-                // Flashcart/Emulator detector
-                if decode_literals {
-                    let test_fn_addr = pool_words[0] - reference_offset;
-                    let integrity_fn_addr = pool_words[1] - reference_offset;
-                    pool_words[0] = test_fn_addr;
-                    pool_words[1] = integrity_fn_addr;
-                }
-                function.constant_pool = EncodedConstantPool::FlashcartEmulatorDetectorType1;
                 log::debug!("Decrypted flashcart/emulator detector (type 1)");
+
+                // Test function address
+                relocations.push(DsProtRelocation { address: function_end_address, offset: reference_offset });
+                // Integrity function address
+                relocations.push(DsProtRelocation { address: function_end_address + 0x4, offset: reference_offset });
             } else if func_start[0..4] == [0xe92d4ff8, 0xe24dd098, 0xe59f2170, 0xe59f4170]
                 || func_start[0..4] == [0xe92d4ff8, 0xe24dd098, 0xe59f2174, 0xe59f4174]
             {
-                // Flashcart/Emulator detector
-                if decode_literals {
-                    let callback_index_addr = pool_words[0] - reference_offset;
-                    let callback_table_addr = pool_words[1] - reference_offset;
-                    let test_fn_addr = pool_words[2] - reference_offset;
-                    let integrity_fn_addr = pool_words[3] - reference_offset;
-                    pool_words[0] = callback_index_addr;
-                    pool_words[1] = callback_table_addr;
-                    pool_words[2] = test_fn_addr;
-                    pool_words[3] = integrity_fn_addr;
-                }
-                function.constant_pool = EncodedConstantPool::FlashcartEmulatorDetectorType2;
                 log::debug!("Decrypted flashcart/emulator detector (type 2)");
+
+                // Callback index address
+                relocations.push(DsProtRelocation { address: function_end_address, offset: reference_offset });
+                // Callback table address
+                relocations.push(DsProtRelocation { address: function_end_address + 0x4, offset: reference_offset });
+                // Test function address
+                relocations.push(DsProtRelocation { address: function_end_address + 0x8, offset: reference_offset });
+                // Integrity function address
+                relocations.push(DsProtRelocation { address: function_end_address + 0xc, offset: reference_offset });
             } else if func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f3070, 0xe3a02000]
                 || func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f3074, 0xe3a02000]
                 || func_start[0..4] == [0xe92d41f0, 0xe24dd080, 0xe59f3080, 0xe3a02000]
             {
-                // Dummy detector
-                if decode_literals {
-                    let test_fn_addr = pool_words[0] - reference_offset;
-                    pool_words[0] = test_fn_addr;
-                }
-                function.constant_pool = EncodedConstantPool::DummyDetector;
                 log::debug!("Decrypted dummy detector");
+
+                // Test function address
+                relocations.push(DsProtRelocation { address: function_end_address, offset: reference_offset });
             } else if func_start[0..4] == [0xe92d4ff8, 0xe24dd018, 0xe59fa100, 0xe59f6100] {
-                // MAC and ROM integrity checkers
-                if decode_literals {
-                    let mac_integrity_fn_addr = pool_words[0] - reference_offset;
-                    let mac_test_fn_addr = pool_words[1] - reference_offset;
-                    let rom_integrity_fn_addr = pool_words[2] - reference_offset;
-                    let rom_test_fn_addr = pool_words[3] - reference_offset;
-                    pool_words[0] = mac_integrity_fn_addr;
-                    pool_words[1] = mac_test_fn_addr;
-                    pool_words[2] = rom_integrity_fn_addr;
-                    pool_words[3] = rom_test_fn_addr;
-                }
-                function.constant_pool = EncodedConstantPool::MacRomIntegrityChecker;
                 log::debug!("Decrypted MAC and ROM integrity checkers");
+
+                // MAC integrity function address
+                relocations.push(DsProtRelocation { address: function_end_address, offset: reference_offset });
+                // MAC test function address
+                relocations.push(DsProtRelocation { address: function_end_address + 0x4, offset: reference_offset });
+                // ROM integrity function address
+                relocations.push(DsProtRelocation { address: function_end_address + 0x8, offset: reference_offset });
+                // ROM test function address
+                relocations.push(DsProtRelocation { address: function_end_address + 0xc, offset: reference_offset });
             } else if func_start[6] == 0x112fff1e {
-                // Integrity checkers
-                if decode_literals {
-                    let checked_fn_addr = pool_words[0] - self.integrity_check_offset();
-                    pool_words[0] = checked_fn_addr;
-                }
-                function.constant_pool = EncodedConstantPool::IntegrityChecker;
                 log::debug!("Decrypted integrity checker");
+
+                // Checked function address
+                relocations.push(DsProtRelocation { address: function_end_address, offset: self.integrity_check_offset() });
             } else if func_start[0..4] == [0xe1a0a00f, 0xe19aa00a, 0x102ee00e, 0xe25aa008] {
-                // Crash
-                if decode_literals {
-                    let clear_fn_addr = pool_words[0] - reference_offset;
-                    let terminate_fn_addr = pool_words[1] - reference_offset;
-                    pool_words[0] = clear_fn_addr;
-                    pool_words[1] = terminate_fn_addr;
-                }
-                function.constant_pool = EncodedConstantPool::Crash;
                 log::debug!("Decrypted crash function");
+
+                // Clear function address
+                relocations.push(DsProtRelocation { address: function_end_address, offset: reference_offset });
+                // Termination function address
+                relocations.push(DsProtRelocation { address: function_end_address + 0x4, offset: reference_offset });
             }
             // The other function types don't have any encrypted constant pools
         }
         Ok(())
     }
 
-    fn decode_function_pointers(
+    fn decode_relocations(
         &self,
         options: &AlgoDecryptOptions,
         words: &mut [u32],
-        encoded_function_pointers: &[EncodedFunctionPointer],
+        relocations: &[DsProtRelocation],
     ) -> Result<(), DsProtError> {
-        if !options.decode_literals {
-            return Ok(());
-        }
-
         let &AlgoDecryptOptions { base_address, end_address, .. } = options;
-        for &encoded_fn_ptr in encoded_function_pointers.iter() {
-            let Some(encoded_fn) = words.get_mut((encoded_fn_ptr.0 - base_address) as usize / 4) else {
-                return OutOfBoundsSnafu {
-                    what: "encoded function pointer",
-                    address: encoded_fn_ptr.0,
-                    base_address,
-                    end_address,
-                }
-                .fail();
+        for relocation in relocations.iter() {
+            let Some(relocated_value) = words.get_mut((relocation.address - base_address) as usize / 4) else {
+                return OutOfBoundsSnafu { what: "relocation", address: relocation.address, base_address, end_address }.fail();
             };
-            *encoded_fn -= self.reference_offset();
+            *relocated_value -= relocation.offset;
         }
         Ok(())
     }
@@ -1125,14 +1121,14 @@ trait DsProtAlgo {
 fn get_constant_pool(
     base_address: u32,
     end_address: u32,
-    words: &mut [u32],
+    words: &[u32],
     func_address: u32,
     func_size: u32,
     pool_size: u32,
-) -> Result<&mut [u32], DsProtError> {
+) -> Result<&[u32], DsProtError> {
     let pool_offset = ((func_address + func_size - base_address) / 4) as usize;
     let wrapper_end_offset = pool_offset + pool_size as usize;
-    let Some(pool_words) = words.get_mut(pool_offset..wrapper_end_offset) else {
+    let Some(pool_words) = words.get(pool_offset..wrapper_end_offset) else {
         return RangeOutOfBoundsSnafu {
             what: "decryption wrapper constant pool",
             start: func_address + func_size,
@@ -1329,8 +1325,8 @@ impl DsProtAlgo for DsProtAlgoV1 {
             version,
             encrypted_ranges,
             bss_variable: None,
-            encrypted_functions: Vec::new(),
-            encoded_function_pointers: Vec::new(),
+            functions: Vec::new(),
+            relocations: Vec::new(),
         })
     }
 }
@@ -1784,12 +1780,12 @@ pub struct DsProtDecryptResult {
     /// Address of the DS Protect BSS variable. Used for offsetting constants.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bss_variable: Option<u32>,
-    /// List of encrypted functions.
+    /// List of functions.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub encrypted_functions: Vec<EncryptedFunction>,
-    /// List of encoded function pointers.
+    pub functions: Vec<DsProtFunction>,
+    /// List of relocations.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
-    pub encoded_function_pointers: Vec<EncodedFunctionPointer>,
+    pub relocations: Vec<DsProtRelocation>,
 }
 
 impl DsProtDecryptResult {
@@ -1798,7 +1794,12 @@ impl DsProtDecryptResult {
         DisplayDsProtDecryptResult { inner: self, indent }
     }
 
-    pub(crate) fn encrypt(&self, data: &mut [u8], base_address: u32) -> Result<(), DsProtError> {
+    pub(crate) fn encrypt(
+        &self,
+        data: &mut [u8],
+        base_address: u32,
+        options: &DsProtEncryptOptions,
+    ) -> Result<(), DsProtError> {
         let Some(dsprot_version) = DSPROT_VERSIONS.iter().find(|v| v.number == self.version) else {
             return Ok(());
         };
@@ -1808,7 +1809,11 @@ impl DsProtDecryptResult {
         // Make 32-bit chunks
         let words: &mut [u32] = bytemuck::cast_slice_mut(data);
 
-        dsprot_version.algo.encrypt(words, self, &AlgoEncryptOptions { base_address, end_address })
+        dsprot_version.algo.encrypt(words, self, &AlgoEncryptOptions {
+            base_address,
+            end_address,
+            encode_relocations: options.encode_relocations,
+        })
     }
 }
 
@@ -1832,12 +1837,12 @@ impl Display for DisplayDsProtDecryptResult<'_> {
         if let Some(bss_variable) = inner.bss_variable {
             writeln!(f, "{i}BSS variable ............... : {:#010x}", bss_variable)?;
         }
-        if !inner.encrypted_functions.is_empty() {
-            writeln!(f, "{i}Encrypted functions ........ :")?;
-            for function in &inner.encrypted_functions {
-                writeln!(f, "{i}  Address ................ : {:#010x}", function.address)?;
-                writeln!(f, "{i}  Size ................... : {:#x}", function.size)?;
-                write!(f, "{i}  Encryption ............. : ")?;
+        if !inner.functions.is_empty() {
+            writeln!(f, "{i}Functions .................. :")?;
+            for function in &inner.functions {
+                writeln!(f, "{i}  Address ..... : {:#010x}", function.address)?;
+                writeln!(f, "{i}  Size ........ : {:#x}", function.size)?;
+                write!(f, "{i}  Encryption .. : ")?;
                 match function.encryption {
                     EncryptionType::None => {
                         writeln!(f, "None")?;
@@ -1849,13 +1854,14 @@ impl Display for DisplayDsProtDecryptResult<'_> {
                         writeln!(f, "Keyed ({:#x})", seed_key)?;
                     }
                 }
-                writeln!(f, "{i}  Encoded constant pool .. : {:?}\n", function.constant_pool)?;
+                writeln!(f)?;
             }
         }
-        if !inner.encoded_function_pointers.is_empty() {
-            writeln!(f, "{i}Encoded function pointers .. :")?;
-            for fn_ptr in &inner.encoded_function_pointers {
-                writeln!(f, "{i}  Address .. : {:#010x}", fn_ptr.0)?;
+        if !inner.relocations.is_empty() {
+            writeln!(f, "{i}Relocations ................ :")?;
+            for fn_ptr in &inner.relocations {
+                writeln!(f, "{i}  Address .. : {:#010x}", fn_ptr.address)?;
+                writeln!(f, "{i}  Offset ... : {:#x}\n", fn_ptr.offset)?;
             }
         }
         Ok(())
@@ -1882,38 +1888,32 @@ impl EncryptedRange {
     }
 }
 
-/// Contains information about an encrypted function.
+/// Contains information about a DS Protect function.
 #[derive(Serialize, Deserialize, Clone, PartialEq, Eq, Debug)]
-pub struct EncryptedFunction {
+pub struct DsProtFunction {
     address: u32,
     size: u32,
     encryption: EncryptionType,
-    constant_pool: EncodedConstantPool,
 }
 
-impl EncryptedFunction {
-    /// Returns the address of this [`EncryptedFunction`].
+impl DsProtFunction {
+    /// Returns the address of this [`DsProtFunction`].
     pub fn address(&self) -> u32 {
         self.address
     }
 
-    /// Returns the size of this [`EncryptedFunction`].
+    /// Returns the size of this [`DsProtFunction`].
     pub fn size(&self) -> u32 {
         self.size
     }
 
-    /// Returns the [`EncryptionType`] of this [`EncryptedFunction`].
+    /// Returns the [`EncryptionType`] of this [`DsProtFunction`].
     pub fn encryption(&self) -> EncryptionType {
         self.encryption
     }
-
-    /// Returns the [`EncodedConstantPool`] of this [`EncryptedFunction`].
-    pub fn constant_pool(&self) -> EncodedConstantPool {
-        self.constant_pool
-    }
 }
 
-/// The type of encryption used on an [`EncryptedFunction`].
+/// The type of encryption used on a [`DsProtFunction`].
 #[derive(Clone, Copy, Serialize, Deserialize, PartialEq, Eq, Debug)]
 pub enum EncryptionType {
     /// No encryption, only encoded constant pool.
@@ -1927,53 +1927,22 @@ pub enum EncryptionType {
     Keyed(u32),
 }
 
-/// Represents a type of DS Protect function whose constant pool contains encoded values.
-#[derive(Debug, Serialize, Deserialize, PartialEq, Eq, Clone, Copy)]
-pub enum EncodedConstantPool {
-    /// No encoding, only encryption.
-    None,
-    /// Encodes an array of (function address, function size).
-    ObfuscatedFunctionTable {
-        /// The number of (function address, function size) entries.
-        length: u32,
-        /// If true, a pointer to DS Protect's garbage data was appended to the end of the constant pool.
-        with_garbage: bool,
-        /// If true, a pointer to this decoder function was appended to the end of the constant pool.
-        with_overwrite: bool,
-    },
-    /// Encodes BSS var address, dest function size, seed key, dest function address, optionally pointer to garbage.
-    DecryptionWrapperType1 {
-        /// If true, a pointer to DS Protect's garbage data was appended to the end of the constant pool.
-        with_garbage: bool,
-    },
-    /// Encodes BSS var address, seed key, dest function address, dest function size, wrapper fragment address.
-    DecryptionWrapperType2 {
-        /// If true, a pointer to DS Protect's garbage data was appended to the end of the constant pool.
-        with_garbage: bool,
-    },
-    /// Encodes BSS var address, seed key placeholder, dest function address, dest function size, wrapper fragment address.
-    DecryptionWrapperType3 {
-        /// If true, a pointer to DS Protect's garbage data was appended to the end of the constant pool.
-        with_garbage: bool,
-    },
-    /// Encodes test function address, integrity checker address.
-    FlashcartEmulatorDetectorType1,
-    /// Encodes callback index address, callback table address, test function address, integrity checker address.
-    FlashcartEmulatorDetectorType2,
-    /// Encodes test function address.
-    DummyDetector,
-    /// Encodes checked function address.
-    IntegrityChecker,
-    /// Encodes two sets of checked function address, test function address.
-    MacRomIntegrityChecker,
-    /// Encodes memory clear function address, terminate function address.
-    Crash,
+struct FunctionTable {
+    /// The number of (function address, function size) entries.
+    length: u32,
+    /// If true, a pointer to DS Protect's garbage data was appended to the end of the constant pool.
+    with_garbage: bool,
+    /// If true, a pointer to this decoder function was appended to the end of the constant pool.
+    with_overwrite: bool,
 }
 
-/// Represents a function pointer in a data section, which was encoded by adding the reference
-/// offset value.
+/// Represents a pointer or constant in DS Protect's code which was encoded by adding an offset
+/// value to it.
 #[derive(PartialEq, Eq, Clone, Copy, Serialize, Deserialize, Debug)]
-pub struct EncodedFunctionPointer(u32);
+pub struct DsProtRelocation {
+    address: u32,
+    offset: u32,
+}
 
 /// Defines whether DS Protect is present in the ARM9 program or an ARM9 overlay, and whether it
 /// is currently encrypted.

--- a/lib/src/crypto/dsprot.rs
+++ b/lib/src/crypto/dsprot.rs
@@ -309,7 +309,7 @@ pub enum DsProtError {
 }
 
 /// Options for [`DsProtInfo::decrypt`].
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct DsProtDecryptOptions {
     /// If true, pointers and constants will be decoded. This applies to constant pools and global
     /// variables managed by DS Protect.
@@ -317,7 +317,7 @@ pub struct DsProtDecryptOptions {
 }
 
 /// Options for [`DsProtDecryptResult::encrypt`].
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct DsProtEncryptOptions {
     /// If true, pointers and constants will be decoded. This applies to constant pools and global
     /// variables managed by DS Protect.
@@ -1946,9 +1946,10 @@ pub struct DsProtRelocation {
 
 /// Defines whether DS Protect is present in the ARM9 program or an ARM9 overlay, and whether it
 /// is currently encrypted.
-#[derive(Clone, PartialEq, Eq, Debug)]
+#[derive(Clone, PartialEq, Eq, Debug, Serialize, Deserialize, Default)]
 pub enum DsProtState {
     /// Not present.
+    #[default]
     None,
     /// Present and unencrypted.
     Unencrypted(DsProtDecryptResult),

--- a/lib/src/crypto/mod.rs
+++ b/lib/src/crypto/mod.rs
@@ -6,3 +6,9 @@ pub mod hmac_sha1;
 
 /// RSA signature type, no de/encryption yet.
 pub mod rsa;
+
+/// DS Protect de-obfuscation.
+pub mod dsprot;
+
+/// Modified RC4 stream cipher implementation.
+pub mod rc4;

--- a/lib/src/crypto/rc4.rs
+++ b/lib/src/crypto/rc4.rs
@@ -1,0 +1,94 @@
+/// Generates a pseudorandom keystream using the RC4 stream cipher.
+pub struct Rc4 {
+    x: Option<u8>,
+    i: u8,
+    j: u8,
+    s: [u8; 256],
+}
+
+impl Rc4 {
+    /// Initializes the RC4 permutation using a variable-length key.
+    pub fn new(key: &[u8], x: Option<u8>) -> Self {
+        // Identity permutation
+        let mut s = [0; 256];
+        for i in 0..256 {
+            s[i] = i as u8;
+        }
+
+        let mut j = 0usize;
+        for i in 0..256 {
+            // Accessing S in reverse is a deviation from standard RC4
+            j = (j + s[255 - i] as usize + key[i % key.len()] as usize) & 0xff;
+            s.swap(j, 255 - i);
+        }
+
+        Self { x, i: 0, j: 0, s }
+    }
+
+    fn s(&self, index: u8) -> u8 {
+        self.s[index as usize]
+    }
+
+    /// Yields the next byte in the keystream.
+    pub fn byte(&mut self) -> u8 {
+        let x = self.x.unwrap_or(0);
+        self.i = self.i.wrapping_add(1).wrapping_add(x);
+        self.j = self.j.wrapping_add(self.s(self.i)).wrapping_add(x);
+
+        self.s.swap(self.i as usize, self.j as usize);
+
+        let t = self.s(self.i).wrapping_add(self.s(self.j));
+        self.s(t)
+    }
+
+    /// Fills `out` with new bytes from the keystream.
+    pub fn bytes(&mut self, out: &mut [u8]) {
+        for o in out.iter_mut() {
+            *o = self.byte();
+        }
+    }
+
+    /// Decrypts the next byte in an encrypted payload.
+    pub fn decrypt_byte(&mut self, b: u8) -> u8 {
+        let result = self.byte() ^ b;
+        if let Some(x) = self.x.as_mut() {
+            *x = b;
+        }
+        result
+    }
+
+    /// Updates the x value using a callback receiving the current value and returning the new value.
+    pub fn update_x<F: FnOnce(u8) -> u8>(&mut self, f: F) {
+        if let Some(x) = self.x.as_mut() {
+            *x = f(*x);
+        }
+    }
+}
+
+#[test]
+fn test_rc4() {
+    let mut rc4 =
+        Rc4::new(&[0xda, 0x6a, 0x00, 0x00, 0x68, 0xb2, 0x6a, 0x00, 0x68, 0x00, 0xb2, 0x6a, 0x02, 0x00, 0x00, 0xb2], None);
+
+    let mut keystream = [0; 32];
+    rc4.bytes(&mut keystream);
+    assert_eq!(keystream, [
+        0x4e, 0x73, 0xc1, 0x63, 0x22, 0x16, 0x6e, 0xe5, 0xfd, 0xb9, 0x78, 0x1f, 0x11, 0xab, 0x28, 0xeb, 0xd3, 0x19, 0xd5,
+        0xac, 0x6c, 0x00, 0x14, 0x65, 0xb7, 0x1d, 0x44, 0x34, 0x46, 0x1d, 0x85, 0x44
+    ])
+}
+
+#[test]
+fn test_rc4_x() {
+    let mut rc4 = Rc4::new(
+        &[0xe3, 0x94, 0x00, 0x00, 0x8c, 0x6f, 0x94, 0x00, 0x8c, 0x00, 0x6f, 0x94, 0x18, 0x00, 0x00, 0x6f],
+        Some(0xaa),
+    );
+
+    let mut keystream = [0; 32];
+    rc4.bytes(&mut keystream);
+    assert_eq!(keystream, [
+        0xb6, 0x03, 0x59, 0x09, 0x01, 0x73, 0x29, 0xbd, 0x19, 0x4a, 0x69, 0xbf, 0xfc, 0x00, 0xe4, 0xfc, 0x89, 0x1b, 0x61,
+        0x88, 0x70, 0xe1, 0x66, 0x5e, 0x0e, 0x15, 0xfb, 0xed, 0x36, 0x77, 0x22, 0xab
+    ])
+}

--- a/lib/src/crypto/rc4.rs
+++ b/lib/src/crypto/rc4.rs
@@ -57,6 +57,15 @@ impl Rc4 {
         result
     }
 
+    /// Encrypts the next byte in an unencrypted payload.
+    pub fn encrypt_byte(&mut self, b: u8) -> u8 {
+        let result = self.byte() ^ b;
+        if let Some(x) = self.x.as_mut() {
+            *x = result;
+        }
+        result
+    }
+
     /// Updates the x value using a callback receiving the current value and returning the new value.
     pub fn update_x<F: FnOnce(u8) -> u8>(&mut self, f: F) {
         if let Some(x) = self.x.as_mut() {

--- a/lib/src/crypto/rsa.rs
+++ b/lib/src/crypto/rsa.rs
@@ -1,7 +1,7 @@
 use std::fmt::Display;
 
 use bytemuck::{Pod, Zeroable};
-use serde::{de::Visitor, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de::Visitor};
 
 /// Represents an RSA signature.
 #[repr(C)]

--- a/lib/src/rom/arm9.rs
+++ b/lib/src/rom/arm9.rs
@@ -15,7 +15,7 @@ use crate::{
     crc::CRC_16_MODBUS,
     crypto::{
         blowfish::{Blowfish, BlowfishError, BlowfishKey, BlowfishLevel},
-        dsprot::{DsProtDecryptDetails, DsProtError, DsProtInfo},
+        dsprot::{DecryptOptions, DsProtDecryptDetails, DsProtError, DsProtInfo},
     },
     rom::LibraryEntry,
 };
@@ -769,14 +769,14 @@ impl<'a> Arm9<'a> {
     /// # Errors
     ///
     /// This function will return an error if [`DsProtInfo::decrypt`] fails.
-    pub fn decrypt_dsprot(&mut self) -> Result<Option<DsProtDecryptDetails>, Arm9DsProtInfoError> {
+    pub fn decrypt_dsprot(&mut self, options: &DecryptOptions) -> Result<Option<DsProtDecryptDetails>, Arm9DsProtInfoError> {
         let Some(dsprot_info) = self.dsprot_info()? else {
             // DS Protect is not used
             return Ok(None);
         };
 
         let base_address = self.base_address();
-        let details = dsprot_info.decrypt(self.data.to_mut(), base_address)?;
+        let details = dsprot_info.decrypt(self.data.to_mut(), base_address, options)?;
 
         Ok(Some(details))
     }

--- a/lib/src/rom/arm9.rs
+++ b/lib/src/rom/arm9.rs
@@ -13,7 +13,10 @@ use super::{
 use crate::{
     compress::lz77::{Lz77, Lz77DecompressError},
     crc::CRC_16_MODBUS,
-    crypto::blowfish::{Blowfish, BlowfishError, BlowfishKey, BlowfishLevel},
+    crypto::{
+        blowfish::{Blowfish, BlowfishError, BlowfishKey, BlowfishLevel},
+        dsprot::{DsProtDecryptDetails, DsProtError, DsProtInfo},
+    },
     rom::LibraryEntry,
 };
 
@@ -161,6 +164,30 @@ pub enum Arm9HmacSha1KeyError {
     HmacSha1KeyCompressed {
         /// Backtrace to the source of the error.
         backtrace: Backtrace,
+    },
+}
+
+/// Errors related to [`Arm9::dsprot_info`].
+#[derive(Debug, Snafu)]
+#[snafu(module)]
+pub enum Arm9DsProtInfoError {
+    /// See [`RawBuildInfoError`].
+    #[snafu(transparent)]
+    RawBuildInfo {
+        /// Source error.
+        source: RawBuildInfoError,
+    },
+    /// Occurs when trying to detect DS Protect while the ARM9 program is compressed.
+    #[snafu(display("ARM9 program must be decompressed before detecting DS Protect:\n{backtrace}"))]
+    Compressed {
+        /// Backtrace to the source of the error.
+        backtrace: Backtrace,
+    },
+    /// See [`DsProtError`].
+    #[snafu(transparent)]
+    DsProtError {
+        /// Source error.
+        source: DsProtError,
     },
 }
 
@@ -720,6 +747,36 @@ impl<'a> Arm9<'a> {
         }
 
         Ok(())
+    }
+
+    /// Looks for DS Protect inside this ARM9 program.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the program is compressed.
+    pub fn dsprot_info(&self) -> Result<Option<DsProtInfo>, Arm9DsProtInfoError> {
+        if self.is_compressed()? {
+            arm9_ds_prot_info_error::CompressedSnafu.fail()
+        } else {
+            Ok(DsProtInfo::detect(&self.data))
+        }
+    }
+
+    /// Decrypts all functions in this ARM9 program that were encrypted by DS Protect.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if [`DsProtInfo::decrypt`] fails.
+    pub fn decrypt_dsprot(&mut self) -> Result<Option<DsProtDecryptDetails>, Arm9DsProtInfoError> {
+        let Some(dsprot_info) = self.dsprot_info()? else {
+            // DS Protect is not used
+            return Ok(None);
+        };
+
+        let base_address = self.base_address();
+        let details = dsprot_info.decrypt(self.data.to_mut(), base_address)?;
+
+        Ok(Some(details))
     }
 }
 

--- a/lib/src/rom/arm9.rs
+++ b/lib/src/rom/arm9.rs
@@ -47,6 +47,11 @@ pub struct Arm9Offsets {
 const SECURE_AREA_ID: [u8; 8] = [0xff, 0xde, 0xff, 0xe7, 0xff, 0xde, 0xff, 0xe7];
 const SECURE_AREA_ENCRY_OBJ: &[u8] = "encryObj".as_bytes();
 
+/// Number of zero-bytes in the secure area for it to be considered unencrypted. This applies to a
+/// few retail games with a secure area which, after decryption, does not start with "encryObj" like
+/// it normally does.
+const SECURE_AREA_UNENCRYPTED_THRESHOLD: usize = 256;
+
 const LZ77: Lz77 = Lz77 {};
 
 const COMPRESSION_START: usize = 0x4000;
@@ -69,12 +74,6 @@ pub enum Arm9Error {
     Blowfish {
         /// Source error.
         source: BlowfishError,
-    },
-    /// Occurs when the string "encryObj" is not found when de/encrypting the secure area.
-    #[snafu(display("invalid encryption, 'encryObj' not found"))]
-    NotEncryObj {
-        /// Backtrace to the source of the error.
-        backtrace: Backtrace,
     },
     /// See [`RawBuildInfoError`].
     #[snafu(transparent)]
@@ -277,7 +276,14 @@ impl<'a> Arm9<'a> {
     /// Returns whether the secure area is encrypted. See [`Self::originally_encrypted`] for whether the secure area was
     /// encrypted originally.
     pub fn is_encrypted(&self) -> bool {
-        self.data.len() < 8 || self.data[0..8] != SECURE_AREA_ID
+        if self.data.len() >= 8 && self.data[0..8] == SECURE_AREA_ID {
+            true
+        } else if self.data.len() >= 0x800 {
+            let zero_count = self.data[0..0x800].iter().filter(|&&b| b == 0).count();
+            zero_count < SECURE_AREA_UNENCRYPTED_THRESHOLD
+        } else {
+            false
+        }
     }
 
     /// Decrypts the secure area. Does nothing if already decrypted.
@@ -305,7 +311,7 @@ impl<'a> Arm9<'a> {
         blowfish.decrypt(&mut secure_area[0..0x800])?;
 
         if &secure_area[0..8] != SECURE_AREA_ENCRY_OBJ {
-            NotEncryObjSnafu {}.fail()?;
+            log::warn!("Failed to decrypt secure area");
         }
 
         secure_area[0..8].copy_from_slice(&SECURE_AREA_ID);
@@ -328,10 +334,6 @@ impl<'a> Arm9<'a> {
             DataTooSmallSnafu { expected: 0x4000usize, actual: self.data.len() }.fail()?;
         }
 
-        if self.data[0..8] != SECURE_AREA_ID {
-            NotEncryObjSnafu {}.fail()?;
-        }
-
         let secure_area = self.encrypted_secure_area(key, gamecode);
         self.data.to_mut()[0..0x4000].copy_from_slice(&secure_area);
         Ok(())
@@ -341,7 +343,7 @@ impl<'a> Arm9<'a> {
     pub fn encrypted_secure_area(&self, key: &BlowfishKey, gamecode: u32) -> [u8; 0x4000] {
         let mut secure_area = [0u8; 0x4000];
         secure_area.copy_from_slice(&self.data[0..0x4000]);
-        if self.is_encrypted() {
+        if self.data[0..8] != SECURE_AREA_ID {
             return secure_area;
         }
 

--- a/lib/src/rom/arm9.rs
+++ b/lib/src/rom/arm9.rs
@@ -4,11 +4,11 @@ use serde::{Deserialize, Serialize};
 use snafu::{Backtrace, Snafu};
 
 use super::{
-    raw::{
-        AutoloadInfo, AutoloadInfoEntry, AutoloadKind, BuildInfo, HmacSha1Signature, HmacSha1SignatureError,
-        RawAutoloadInfoError, RawBuildInfoError, NITROCODE_BYTES,
-    },
     Autoload, OverlayTable,
+    raw::{
+        AutoloadInfo, AutoloadInfoEntry, AutoloadKind, BuildInfo, HmacSha1Signature, HmacSha1SignatureError, NITROCODE_BYTES,
+        RawAutoloadInfoError, RawBuildInfoError,
+    },
 };
 use crate::{
     compress::lz77::{Lz77, Lz77DecompressError},
@@ -277,12 +277,12 @@ impl<'a> Arm9<'a> {
     /// encrypted originally.
     pub fn is_encrypted(&self) -> bool {
         if self.data.len() >= 8 && self.data[0..8] == SECURE_AREA_ID {
-            true
+            false
         } else if self.data.len() >= 0x800 {
             let zero_count = self.data[0..0x800].iter().filter(|&&b| b == 0).count();
             zero_count < SECURE_AREA_UNENCRYPTED_THRESHOLD
         } else {
-            false
+            true
         }
     }
 

--- a/lib/src/rom/arm9.rs
+++ b/lib/src/rom/arm9.rs
@@ -15,22 +15,23 @@ use crate::{
     crc::CRC_16_MODBUS,
     crypto::{
         blowfish::{Blowfish, BlowfishError, BlowfishKey, BlowfishLevel},
-        dsprot::{DecryptOptions, DsProtDecryptDetails, DsProtError, DsProtInfo},
+        dsprot::{DecryptOptions, DsProtDecryptResult, DsProtError, DsProtInfo, DsProtState},
     },
     rom::LibraryEntry,
 };
 
 /// ARM9 program.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Arm9<'a> {
     data: Cow<'a, [u8]>,
     offsets: Arm9Offsets,
     originally_compressed: bool,
     originally_encrypted: bool,
+    dsprot_state: DsProtState,
 }
 
 /// Offsets in the ARM9 program.
-#[derive(Serialize, Deserialize, Clone, Copy)]
+#[derive(Serialize, Deserialize, Clone, Copy, PartialEq, Eq)]
 pub struct Arm9Offsets {
     /// Base address.
     pub base_address: u32,
@@ -196,22 +197,33 @@ pub struct Arm9WithTcmsOptions {
     pub originally_compressed: bool,
     /// Whether the program was encrypted originally.
     pub originally_encrypted: bool,
+    /// DS Protect decryption info, used for re-encrypting DS Protect functions.
+    pub dsprot: Option<DsProtDecryptResult>,
 }
 
 impl<'a> Arm9<'a> {
     /// Creates a new ARM9 program from raw data.
     pub fn new<T: Into<Cow<'a, [u8]>>>(data: T, offsets: Arm9Offsets) -> Result<Self, RawBuildInfoError> {
-        let mut arm9 = Arm9 { data: data.into(), offsets, originally_compressed: false, originally_encrypted: false };
+        let mut arm9 = Arm9 {
+            data: data.into(),
+            offsets,
+            originally_compressed: false,
+            originally_encrypted: false,
+            dsprot_state: DsProtState::None,
+        };
         arm9.originally_compressed = arm9.is_compressed()?;
         arm9.originally_encrypted = arm9.is_encrypted();
         Ok(arm9)
     }
 
+    /// Deprecated, use [`Arm9::with_autoloads`] instead.
+    ///
     /// Creates a new ARM9 program with raw data and two autoloads (ITCM and DTCM).
     ///
     /// # Errors
     ///
     /// See [`Self::build_info_mut`].
+    #[deprecated(note = "use Arm9::with_autoloads instead")]
     pub fn with_two_tcms(
         mut data: Vec<u8>,
         itcm: Autoload,
@@ -228,8 +240,9 @@ impl<'a> Arm9<'a> {
         data.extend(bytemuck::bytes_of(&autoload_infos));
         let autoload_infos_end = data.len() as u32 + offsets.base_address;
 
-        let Arm9WithTcmsOptions { originally_compressed, originally_encrypted } = options;
-        let mut arm9 = Self { data: data.into(), offsets, originally_compressed, originally_encrypted };
+        let Arm9WithTcmsOptions { originally_compressed, originally_encrypted, dsprot } = options;
+        let dsprot_state = if let Some(dsprot) = dsprot { DsProtState::Encrypted(dsprot) } else { DsProtState::None };
+        let mut arm9 = Self { data: data.into(), offsets, originally_compressed, originally_encrypted, dsprot_state };
 
         let build_info = arm9.build_info_mut()?;
         build_info.autoload_blocks = autoload_blocks;
@@ -262,8 +275,9 @@ impl<'a> Arm9<'a> {
         }
         let autoload_infos_end = data.len() as u32 + offsets.base_address;
 
-        let Arm9WithTcmsOptions { originally_compressed, originally_encrypted } = options;
-        let mut arm9 = Self { data: data.into(), offsets, originally_compressed, originally_encrypted };
+        let Arm9WithTcmsOptions { originally_compressed, originally_encrypted, dsprot } = options;
+        let dsprot_state = if let Some(dsprot) = dsprot { DsProtState::Encrypted(dsprot) } else { DsProtState::None };
+        let mut arm9 = Self { data: data.into(), offsets, originally_compressed, originally_encrypted, dsprot_state };
 
         let build_info = arm9.build_info_mut()?;
         build_info.autoload_blocks = autoload_blocks;
@@ -764,21 +778,51 @@ impl<'a> Arm9<'a> {
         }
     }
 
-    /// Decrypts all functions in this ARM9 program that were encrypted by DS Protect.
+    /// Decrypts all functions in this ARM9 program that were encrypted by DS Protect. Does nothing
+    /// if [`Arm9::dsprot_state`] is [`DsProtState::Unencrypted`].
     ///
     /// # Errors
     ///
     /// This function will return an error if [`DsProtInfo::decrypt`] fails.
-    pub fn decrypt_dsprot(&mut self, options: &DecryptOptions) -> Result<Option<DsProtDecryptDetails>, Arm9DsProtInfoError> {
+    pub fn decrypt_dsprot(&mut self, options: &DecryptOptions) -> Result<Option<&DsProtDecryptResult>, Arm9DsProtInfoError> {
         let Some(dsprot_info) = self.dsprot_info()? else {
             // DS Protect is not used
             return Ok(None);
         };
 
         let base_address = self.base_address();
-        let details = dsprot_info.decrypt(self.data.to_mut(), base_address, options)?;
+        let result = dsprot_info.decrypt(self.data.to_mut(), base_address, options)?;
+        self.dsprot_state = DsProtState::Unencrypted(result);
+        let DsProtState::Unencrypted(result) = &self.dsprot_state else { unreachable!() };
+        Ok(Some(result))
+    }
 
-        Ok(Some(details))
+    /// Encrypts DS Protect functions in this ARM9 program. This can only be done if
+    /// [`Arm9::dsprot_state`] is [`DsProtState::Unencrypted`].
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if [`DsProtInfo::decrypt`] fails.
+    pub fn encrypt_dsprot(&mut self) -> Result<(), Arm9DsProtInfoError> {
+        let dsprot_state = std::mem::replace(&mut self.dsprot_state, DsProtState::None);
+        let DsProtState::Unencrypted(dsprot_result) = dsprot_state else {
+            return Ok(());
+        };
+
+        let base_address = self.base_address();
+        dsprot_result.encrypt(self.data.to_mut(), base_address)?;
+        self.dsprot_state = DsProtState::Encrypted(dsprot_result);
+
+        Ok(())
+    }
+
+    /// Returns the [`DsProtState`] of this ARM9 program.
+    pub fn dsprot_state(&self) -> &DsProtState {
+        &self.dsprot_state
+    }
+
+    pub(crate) fn set_dsprot_state(&mut self, dsprot_state: DsProtState) {
+        self.dsprot_state = dsprot_state;
     }
 }
 

--- a/lib/src/rom/arm9.rs
+++ b/lib/src/rom/arm9.rs
@@ -15,7 +15,7 @@ use crate::{
     crc::CRC_16_MODBUS,
     crypto::{
         blowfish::{Blowfish, BlowfishError, BlowfishKey, BlowfishLevel},
-        dsprot::{DecryptOptions, DsProtDecryptResult, DsProtError, DsProtInfo, DsProtState},
+        dsprot::{DsProtDecryptOptions, DsProtDecryptResult, DsProtEncryptOptions, DsProtError, DsProtInfo, DsProtState},
     },
     rom::LibraryEntry,
 };
@@ -784,7 +784,10 @@ impl<'a> Arm9<'a> {
     /// # Errors
     ///
     /// This function will return an error if [`DsProtInfo::decrypt`] fails.
-    pub fn decrypt_dsprot(&mut self, options: &DecryptOptions) -> Result<Option<&DsProtDecryptResult>, Arm9DsProtInfoError> {
+    pub fn decrypt_dsprot(
+        &mut self,
+        options: &DsProtDecryptOptions,
+    ) -> Result<Option<&DsProtDecryptResult>, Arm9DsProtInfoError> {
         let Some(dsprot_info) = self.dsprot_info()? else {
             // DS Protect is not used
             return Ok(None);
@@ -803,14 +806,14 @@ impl<'a> Arm9<'a> {
     /// # Errors
     ///
     /// This function will return an error if [`DsProtInfo::decrypt`] fails.
-    pub fn encrypt_dsprot(&mut self) -> Result<(), Arm9DsProtInfoError> {
+    pub fn encrypt_dsprot(&mut self, options: &DsProtEncryptOptions) -> Result<(), Arm9DsProtInfoError> {
         let dsprot_state = std::mem::replace(&mut self.dsprot_state, DsProtState::None);
         let DsProtState::Unencrypted(dsprot_result) = dsprot_state else {
             return Ok(());
         };
 
         let base_address = self.base_address();
-        dsprot_result.encrypt(self.data.to_mut(), base_address)?;
+        dsprot_result.encrypt(self.data.to_mut(), base_address, options)?;
         self.dsprot_state = DsProtState::Encrypted(dsprot_result);
 
         Ok(())

--- a/lib/src/rom/arm9.rs
+++ b/lib/src/rom/arm9.rs
@@ -197,8 +197,8 @@ pub struct Arm9WithTcmsOptions {
     pub originally_compressed: bool,
     /// Whether the program was encrypted originally.
     pub originally_encrypted: bool,
-    /// DS Protect decryption info, used for re-encrypting DS Protect functions.
-    pub dsprot: Option<DsProtDecryptResult>,
+    /// Current state of DS Protect. Can be absent, encrypted or unencrypted.
+    pub dsprot_state: DsProtState,
 }
 
 impl<'a> Arm9<'a> {
@@ -240,8 +240,7 @@ impl<'a> Arm9<'a> {
         data.extend(bytemuck::bytes_of(&autoload_infos));
         let autoload_infos_end = data.len() as u32 + offsets.base_address;
 
-        let Arm9WithTcmsOptions { originally_compressed, originally_encrypted, dsprot } = options;
-        let dsprot_state = if let Some(dsprot) = dsprot { DsProtState::Encrypted(dsprot) } else { DsProtState::None };
+        let Arm9WithTcmsOptions { originally_compressed, originally_encrypted, dsprot_state } = options;
         let mut arm9 = Self { data: data.into(), offsets, originally_compressed, originally_encrypted, dsprot_state };
 
         let build_info = arm9.build_info_mut()?;
@@ -275,8 +274,7 @@ impl<'a> Arm9<'a> {
         }
         let autoload_infos_end = data.len() as u32 + offsets.base_address;
 
-        let Arm9WithTcmsOptions { originally_compressed, originally_encrypted, dsprot } = options;
-        let dsprot_state = if let Some(dsprot) = dsprot { DsProtState::Encrypted(dsprot) } else { DsProtState::None };
+        let Arm9WithTcmsOptions { originally_compressed, originally_encrypted, dsprot_state } = options;
         let mut arm9 = Self { data: data.into(), offsets, originally_compressed, originally_encrypted, dsprot_state };
 
         let build_info = arm9.build_info_mut()?;
@@ -765,19 +763,6 @@ impl<'a> Arm9<'a> {
         Ok(())
     }
 
-    /// Looks for DS Protect inside this ARM9 program.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if the program is compressed.
-    pub fn dsprot_info(&self) -> Result<Option<DsProtInfo>, Arm9DsProtInfoError> {
-        if self.is_compressed()? {
-            arm9_ds_prot_info_error::CompressedSnafu.fail()
-        } else {
-            Ok(DsProtInfo::detect(&self.data))
-        }
-    }
-
     /// Decrypts all functions in this ARM9 program that were encrypted by DS Protect. Does nothing
     /// if [`Arm9::dsprot_state`] is [`DsProtState::Unencrypted`].
     ///
@@ -788,16 +773,29 @@ impl<'a> Arm9<'a> {
         &mut self,
         options: &DsProtDecryptOptions,
     ) -> Result<Option<&DsProtDecryptResult>, Arm9DsProtInfoError> {
-        let Some(dsprot_info) = self.dsprot_info()? else {
-            // DS Protect is not used
-            return Ok(None);
-        };
+        if self.dsprot_state.is_unencrypted() {
+            // Can't flatten this code due to conditional reference return (known borrow checker limitation)
+            if let DsProtState::Unencrypted(result) = &self.dsprot_state {
+                Ok(Some(result))
+            } else {
+                unreachable!();
+            }
+        } else {
+            let dsprot_info = if self.is_compressed()? {
+                return arm9_ds_prot_info_error::CompressedSnafu.fail();
+            } else if let Some(dsprot_info) = DsProtInfo::detect(&self.data) {
+                dsprot_info
+            } else {
+                // DS Protect is not used
+                return Ok(None);
+            };
 
-        let base_address = self.base_address();
-        let result = dsprot_info.decrypt(self.data.to_mut(), base_address, options)?;
-        self.dsprot_state = DsProtState::Unencrypted(result);
-        let DsProtState::Unencrypted(result) = &self.dsprot_state else { unreachable!() };
-        Ok(Some(result))
+            let base_address = self.base_address();
+            let result = dsprot_info.decrypt(self.data.to_mut(), base_address, options)?;
+            self.dsprot_state = DsProtState::Unencrypted(result);
+            let DsProtState::Unencrypted(result) = &self.dsprot_state else { unreachable!() };
+            Ok(Some(result))
+        }
     }
 
     /// Encrypts DS Protect functions in this ARM9 program. This can only be done if

--- a/lib/src/rom/banner.rs
+++ b/lib/src/rom/banner.rs
@@ -8,8 +8,8 @@ use serde::{Deserialize, Serialize};
 use snafu::{Backtrace, Snafu};
 
 use super::{
-    raw::{self, BannerBitmap, BannerPalette, BannerVersion, Language},
     ImageSize,
+    raw::{self, BannerBitmap, BannerPalette, BannerVersion, Language},
 };
 use crate::{crc::CRC_16_MODBUS, str::Unicode16Array};
 

--- a/lib/src/rom/config.rs
+++ b/lib/src/rom/config.rs
@@ -5,11 +5,6 @@ use serde::{Deserialize, Serialize};
 /// Config file mainly consisting of paths to extracted files.
 #[derive(Serialize, Deserialize, Clone)]
 pub struct RomConfig {
-    /// Byte value to append between files in the file image block.
-    pub file_image_padding_value: u8,
-    /// Byte value to append between sections in the file image block.
-    pub section_padding_value: u8,
-
     /// Path to header YAML, deserializes into [`Header`](crate::rom::Header).
     pub header: PathBuf,
     /// Path to header logo PNG, loaded by [`Logo::from_png`](crate::rom::Logo::from_png).
@@ -54,6 +49,9 @@ pub struct RomConfig {
 
     /// Alignment of ROM sections
     pub alignment: RomConfigAlignment,
+
+    /// Padding values for aligning ROM sections
+    pub padding: RomConfigPaddingValues,
 }
 
 /// Path to autoload files
@@ -100,4 +98,31 @@ pub struct RomConfigAlignment {
     pub file_image_block: u32,
     /// Alignment of each file.
     pub file: u32,
+}
+
+/// Byte values to append when aligning ROM sections.
+#[derive(Serialize, Deserialize, Clone)]
+pub struct RomConfigPaddingValues {
+    /// Before the ARM9 program.
+    pub arm9: u8,
+    /// Before the ARM9 overlay table.
+    pub arm9_overlay_table: u8,
+    /// Before ARM9 overlays.
+    pub arm9_overlays: u8,
+    /// Before ARM7 program.
+    pub arm7: u8,
+    /// Before the ARM7 overlay table.
+    pub arm7_overlay_table: u8,
+    /// Before ARM7 overlays.
+    pub arm7_overlays: u8,
+    /// Before the file name table.
+    pub fnt: u8,
+    /// Before the file allocation table.
+    pub fat: u8,
+    /// Before the banner section.
+    pub banner: u8,
+    /// Before files in the file image block.
+    pub file_image: u8,
+    /// Aligning the ROM size to a power of two.
+    pub rom: u8,
 }

--- a/lib/src/rom/file.rs
+++ b/lib/src/rom/file.rs
@@ -13,7 +13,7 @@ use snafu::{Backtrace, Snafu};
 
 use super::raw::{self, FileAlloc, Fnt, FntDirectory, FntFile, FntSubtable, RawHeaderError};
 use crate::{
-    io::{read_dir, read_file, FileError},
+    io::{FileError, read_dir, read_file},
     str::BlobSize,
 };
 
@@ -463,7 +463,11 @@ impl<'a> FileSystem<'a> {
         let mut max_id = 0;
         let parent = self.dir(parent_id);
         for child in &parent.children {
-            let id = if Self::is_dir(*child) { self.max_file_id_in(*child) } else { *child };
+            let id = if Self::is_dir(*child) {
+                self.max_file_id_in(*child)
+            } else {
+                *child
+            };
             if id > max_id {
                 max_id = id;
             }

--- a/lib/src/rom/header.rs
+++ b/lib/src/rom/header.rs
@@ -7,11 +7,11 @@ use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 
 use super::{
+    BuildContext, Rom,
     raw::{
         self, AccessControl, Capacity, Delay, DsFlags, DsiFlags, DsiFlags2, HeaderVersion, ProgramOffset, RegionFlags,
         TableOffset,
     },
-    BuildContext, Rom,
 };
 use crate::{
     crc::CRC_16_MODBUS,

--- a/lib/src/rom/logo.rs
+++ b/lib/src/rom/logo.rs
@@ -302,11 +302,7 @@ impl Logo {
     }
 
     fn get_pixel_value(&self, x: usize, y: usize, value: u8) -> u8 {
-        if self.get_pixel(x, y) {
-            value
-        } else {
-            0
-        }
+        if self.get_pixel(x, y) { value } else { 0 }
     }
 
     fn get_braille_index(&self, x: usize, y: usize) -> u8 {

--- a/lib/src/rom/overlay.rs
+++ b/lib/src/rom/overlay.rs
@@ -16,6 +16,7 @@ use crate::{
 #[derive(Clone)]
 pub struct Overlay<'a> {
     originally_compressed: bool,
+    originally_signed: bool,
     info: OverlayInfo,
     signature: Option<HmacSha1Signature>,
     data: Cow<'a, [u8]>,
@@ -27,6 +28,8 @@ const LZ77: Lz77 = Lz77 {};
 pub struct OverlayOptions {
     /// Whether the overlay was originally compressed.
     pub originally_compressed: bool,
+    /// Whether the overlay was originally signed.
+    pub originally_signed: bool,
     /// Overlay info.
     pub info: OverlayInfo,
 }
@@ -75,10 +78,10 @@ pub enum OverlayError {
 impl<'a> Overlay<'a> {
     /// Creates a new [`Overlay`] from plain data.
     pub fn new<T: Into<Cow<'a, [u8]>>>(data: T, options: OverlayOptions) -> Result<Self, OverlayError> {
-        let OverlayOptions { originally_compressed, info } = options;
+        let OverlayOptions { originally_compressed, originally_signed, info } = options;
         let data = data.into();
 
-        Ok(Self { originally_compressed, info, signature: None, data })
+        Ok(Self { originally_compressed, originally_signed, info, signature: None, data })
     }
 
     /// Parses an ARM9 [`Overlay`] from a ROM.
@@ -101,6 +104,7 @@ impl<'a> Overlay<'a> {
 
         let overlay = Self {
             originally_compressed: overlay.flags.is_compressed(),
+            originally_signed: overlay.flags.is_signed(),
             info: OverlayInfo::new(overlay),
             signature,
             data: Cow::Borrowed(data),
@@ -126,6 +130,7 @@ impl<'a> Overlay<'a> {
 
         let overlay = Self {
             originally_compressed: overlay.flags.is_compressed(),
+            originally_signed: overlay.flags.is_signed(),
             info: OverlayInfo::new(overlay),
             signature: None,
             data: Cow::Borrowed(data),
@@ -201,7 +206,8 @@ impl<'a> Overlay<'a> {
         self.info.compressed
     }
 
-    /// Returns whether this [`Overlay`] has a signature.
+    /// Returns whether this [`Overlay`] has a signature. See [`Self::originally_signed`] for whether this overlay was
+    /// signed originally.
     pub fn is_signed(&self) -> bool {
         self.signature.is_some()
     }
@@ -248,6 +254,11 @@ impl<'a> Overlay<'a> {
     /// Returns whether this [`Overlay`] was compressed originally. See [`Self::is_compressed`] for the current state.
     pub fn originally_compressed(&self) -> bool {
         self.originally_compressed
+    }
+
+    /// Returns whether this [`Overlay`] was compressed signed. See [`Self::is_signed`] for the current state.
+    pub fn originally_signed(&self) -> bool {
+        self.originally_signed
     }
 
     /// Computes the signature of this [`Overlay`] using the given HMAC-SHA1 key.

--- a/lib/src/rom/overlay.rs
+++ b/lib/src/rom/overlay.rs
@@ -9,7 +9,10 @@ use super::{
 };
 use crate::{
     compress::lz77::{Lz77, Lz77DecompressError},
-    crypto::hmac_sha1::HmacSha1,
+    crypto::{
+        dsprot::{DsProtDecryptDetails, DsProtError, DsProtInfo},
+        hmac_sha1::HmacSha1,
+    },
 };
 
 /// An overlay module for ARM9/ARM7.
@@ -72,6 +75,24 @@ pub enum OverlayError {
     OverlayCompression {
         /// Backtrace to the source of the error.
         backtrace: Backtrace,
+    },
+}
+
+/// Errors related to [`Overlay::dsprot_info`] and [`Overlay::decrypt_dsprot`].
+#[derive(Debug, Snafu)]
+#[snafu(module)]
+pub enum OverlayDsProtError {
+    /// Occurs when trying to detect DS Protect while the overlay is compressed.
+    #[snafu(display("overlay must be decompressed before detecting DS Protect:\n{backtrace}"))]
+    Compressed {
+        /// Backtrace to the source of the error.
+        backtrace: Backtrace,
+    },
+    /// See [`DsProtError`].
+    #[snafu(transparent)]
+    DsProtError {
+        /// Source error.
+        source: DsProtError,
     },
 }
 
@@ -289,6 +310,36 @@ impl<'a> Overlay<'a> {
     pub fn sign(&mut self, hmac_sha1: &HmacSha1) -> Result<(), OverlayError> {
         self.signature = Some(self.compute_signature(hmac_sha1)?);
         Ok(())
+    }
+
+    /// Looks for DS Protect inside this overlay.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if the overlay is compressed.
+    pub fn dsprot_info(&self) -> Result<Option<DsProtInfo>, OverlayDsProtError> {
+        if self.is_compressed() {
+            overlay_ds_prot_error::CompressedSnafu.fail()
+        } else {
+            Ok(DsProtInfo::detect(&self.data))
+        }
+    }
+
+    /// Decrypts all functions in this overlay that were encrypted by DS Protect.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if [`DsProtInfo::decrypt`] fails.
+    pub fn decrypt_dsprot(&mut self) -> Result<Option<DsProtDecryptDetails>, OverlayDsProtError> {
+        let Some(dsprot_info) = self.dsprot_info()? else {
+            // DS Protect is not used
+            return Ok(None);
+        };
+
+        let base_address = self.base_address();
+        let details = dsprot_info.decrypt(self.data.to_mut(), base_address)?;
+
+        Ok(Some(details))
     }
 }
 

--- a/lib/src/rom/overlay.rs
+++ b/lib/src/rom/overlay.rs
@@ -13,6 +13,7 @@ use crate::{
         dsprot::{DsProtDecryptDetails, DsProtError, DsProtInfo},
         hmac_sha1::HmacSha1,
     },
+    rom::Arm9HmacSha1KeyError,
 };
 
 /// An overlay module for ARM9/ARM7.
@@ -58,12 +59,6 @@ pub enum OverlayError {
         /// Source error.
         source: Arm9OverlaySignaturesError,
     },
-    /// Occurs when there are no overlay signatures in the ARM9 program.
-    #[snafu(display("no overlay signatures found in ARM9 program:\n{backtrace}"))]
-    NoOverlaySignatures {
-        /// Backtrace to the source of the error.
-        backtrace: Backtrace,
-    },
     /// Occurs when trying to create a signed ARM7 overlay, but signing ARM7 overlays is not supported.
     #[snafu(display("signing ARM7 overlays is not supported:\n{backtrace}"))]
     SignedArm7Overlay {
@@ -75,6 +70,12 @@ pub enum OverlayError {
     OverlayCompression {
         /// Backtrace to the source of the error.
         backtrace: Backtrace,
+    },
+    /// Occurs when trying to compute the signature while parsing the ROM, but the original signature was not found in ARM9.
+    #[snafu(transparent)]
+    Arm9HmacSha1Key {
+        /// Source error.
+        source: Arm9HmacSha1KeyError,
     },
 }
 
@@ -116,22 +117,31 @@ impl<'a> Overlay<'a> {
         let alloc = fat[overlay.file_id as usize];
         let data = &rom.data()[alloc.range()];
 
-        let mut signature = None;
-        if overlay.flags.is_signed() {
-            let num_overlays = rom.num_arm9_overlays()?;
-            let signatures = arm9.overlay_signatures(num_overlays)?;
-            signature = Some(signatures.map(|s| s[overlay.id as usize]).ok_or_else(|| NoOverlaySignaturesSnafu {}.build())?);
-        }
-
-        let overlay = Self {
+        let mut parsed_overlay = Self {
             originally_compressed: overlay.flags.is_compressed(),
             originally_signed: overlay.flags.is_signed(),
             info: OverlayInfo::new(overlay),
-            signature,
+            signature: None,
             data: Cow::Borrowed(data),
         };
 
-        Ok(overlay)
+        if overlay.flags.is_signed() {
+            let num_overlays = rom.num_arm9_overlays()?;
+            let signatures = arm9.overlay_signatures(num_overlays)?;
+            if let Some(signatures) = signatures {
+                parsed_overlay.signature = Some(signatures[overlay.id as usize]);
+            } else if let Some(key) = arm9.hmac_sha1_key()? {
+                // Compute the signature if it's missing
+                parsed_overlay.sign(&HmacSha1::new(key))?;
+            } else {
+                log::error!(
+                    "ARM9 overlay {} was marked as signed, but no signature or HMAC-SHA1 key was found in ARM9",
+                    overlay.id
+                );
+            }
+        }
+
+        Ok(parsed_overlay)
     }
 
     /// Parses an ARM7 [`Overlay`] from a ROM.

--- a/lib/src/rom/overlay.rs
+++ b/lib/src/rom/overlay.rs
@@ -4,13 +4,13 @@ use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 
 use super::{
-    raw::{self, HmacSha1Signature, OverlayFlags, RawFatError, RawHeaderError},
     Arm9, Arm9OverlaySignaturesError,
+    raw::{self, HmacSha1Signature, OverlayFlags, RawFatError, RawHeaderError},
 };
 use crate::{
     compress::lz77::{Lz77, Lz77DecompressError},
     crypto::{
-        dsprot::{DsProtDecryptDetails, DsProtError, DsProtInfo},
+        dsprot::{DecryptOptions, DsProtDecryptDetails, DsProtError, DsProtInfo},
         hmac_sha1::HmacSha1,
     },
     rom::Arm9HmacSha1KeyError,
@@ -328,11 +328,7 @@ impl<'a> Overlay<'a> {
     ///
     /// This function will return an error if the overlay is compressed.
     pub fn dsprot_info(&self) -> Result<Option<DsProtInfo>, OverlayDsProtError> {
-        if self.is_compressed() {
-            overlay_ds_prot_error::CompressedSnafu.fail()
-        } else {
-            Ok(DsProtInfo::detect(&self.data))
-        }
+        if self.is_compressed() { overlay_ds_prot_error::CompressedSnafu.fail() } else { Ok(DsProtInfo::detect(&self.data)) }
     }
 
     /// Decrypts all functions in this overlay that were encrypted by DS Protect.
@@ -340,14 +336,14 @@ impl<'a> Overlay<'a> {
     /// # Errors
     ///
     /// This function will return an error if [`DsProtInfo::decrypt`] fails.
-    pub fn decrypt_dsprot(&mut self) -> Result<Option<DsProtDecryptDetails>, OverlayDsProtError> {
+    pub fn decrypt_dsprot(&mut self, options: &DecryptOptions) -> Result<Option<DsProtDecryptDetails>, OverlayDsProtError> {
         let Some(dsprot_info) = self.dsprot_info()? else {
             // DS Protect is not used
             return Ok(None);
         };
 
         let base_address = self.base_address();
-        let details = dsprot_info.decrypt(self.data.to_mut(), base_address)?;
+        let details = dsprot_info.decrypt(self.data.to_mut(), base_address, options)?;
 
         Ok(Some(details))
     }

--- a/lib/src/rom/overlay.rs
+++ b/lib/src/rom/overlay.rs
@@ -10,7 +10,7 @@ use super::{
 use crate::{
     compress::lz77::{Lz77, Lz77DecompressError},
     crypto::{
-        dsprot::{DecryptOptions, DsProtDecryptResult, DsProtError, DsProtInfo, DsProtState},
+        dsprot::{DsProtDecryptOptions, DsProtDecryptResult, DsProtEncryptOptions, DsProtError, DsProtInfo, DsProtState},
         hmac_sha1::HmacSha1,
     },
     rom::Arm9HmacSha1KeyError,
@@ -344,7 +344,10 @@ impl<'a> Overlay<'a> {
     /// # Errors
     ///
     /// This function will return an error if [`DsProtInfo::decrypt`] fails.
-    pub fn decrypt_dsprot(&mut self, options: &DecryptOptions) -> Result<Option<&DsProtDecryptResult>, OverlayDsProtError> {
+    pub fn decrypt_dsprot(
+        &mut self,
+        options: &DsProtDecryptOptions,
+    ) -> Result<Option<&DsProtDecryptResult>, OverlayDsProtError> {
         let Some(dsprot_info) = self.dsprot_info()? else {
             // DS Protect is not used
             return Ok(None);
@@ -363,7 +366,7 @@ impl<'a> Overlay<'a> {
     /// # Errors
     ///
     /// This function will return an error if [`DsProtInfo::decrypt`] fails.
-    pub fn encrypt_dsprot(&mut self) -> Result<(), OverlayDsProtError> {
+    pub fn encrypt_dsprot(&mut self, options: &DsProtEncryptOptions) -> Result<(), OverlayDsProtError> {
         let dsprot_state = std::mem::replace(&mut self.dsprot_state, DsProtState::None);
         let DsProtState::Unencrypted(dsprot_result) = dsprot_state else {
             self.dsprot_state = dsprot_state; // revert replace
@@ -371,7 +374,7 @@ impl<'a> Overlay<'a> {
         };
 
         let base_address = self.base_address();
-        dsprot_result.encrypt(self.data.to_mut(), base_address)?;
+        dsprot_result.encrypt(self.data.to_mut(), base_address, options)?;
         self.dsprot_state = DsProtState::Encrypted(dsprot_result);
 
         Ok(())

--- a/lib/src/rom/overlay.rs
+++ b/lib/src/rom/overlay.rs
@@ -37,8 +37,8 @@ pub struct OverlayOptions {
     pub originally_signed: bool,
     /// Overlay info.
     pub info: OverlayInfo,
-    /// DS Protect decryption info, used for re-encrypting DS Protect functions.
-    pub dsprot: Option<DsProtDecryptResult>,
+    /// Current state of DS Protect. Can be absent, encrypted or unencrypted.
+    pub dsprot_state: DsProtState,
 }
 
 /// Errors related to [`Overlay`].
@@ -82,7 +82,7 @@ pub enum OverlayError {
     },
 }
 
-/// Errors related to [`Overlay::dsprot_info`] and [`Overlay::decrypt_dsprot`].
+/// Errors related to [`Overlay::decrypt_dsprot`] and [`Overlay::encrypt_dsprot`].
 #[derive(Debug, Snafu)]
 #[snafu(module)]
 pub enum OverlayDsProtError {
@@ -103,10 +103,8 @@ pub enum OverlayDsProtError {
 impl<'a> Overlay<'a> {
     /// Creates a new [`Overlay`] from plain data.
     pub fn new<T: Into<Cow<'a, [u8]>>>(data: T, options: OverlayOptions) -> Result<Self, OverlayError> {
-        let OverlayOptions { originally_compressed, originally_signed, info, dsprot } = options;
+        let OverlayOptions { originally_compressed, originally_signed, info, dsprot_state } = options;
         let data = data.into();
-
-        let dsprot_state = if let Some(dsprot) = dsprot { DsProtState::Encrypted(dsprot) } else { DsProtState::None };
 
         Ok(Self { originally_compressed, originally_signed, info, signature: None, data, dsprot_state })
     }
@@ -329,15 +327,6 @@ impl<'a> Overlay<'a> {
         Ok(())
     }
 
-    /// Looks for DS Protect inside this overlay.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if the overlay is compressed.
-    pub fn dsprot_info(&self) -> Result<Option<DsProtInfo>, OverlayDsProtError> {
-        if self.is_compressed() { overlay_ds_prot_error::CompressedSnafu.fail() } else { Ok(DsProtInfo::detect(&self.data)) }
-    }
-
     /// Decrypts all functions in this overlay that were encrypted by DS Protect. Does nothing if
     /// [`Overlay::dsprot_state`] is [`DsProtState::Unencrypted`].
     ///
@@ -348,16 +337,29 @@ impl<'a> Overlay<'a> {
         &mut self,
         options: &DsProtDecryptOptions,
     ) -> Result<Option<&DsProtDecryptResult>, OverlayDsProtError> {
-        let Some(dsprot_info) = self.dsprot_info()? else {
-            // DS Protect is not used
-            return Ok(None);
-        };
+        if self.dsprot_state.is_unencrypted() {
+            // Can't flatten this code due to conditional reference return (known borrow checker limitation)
+            if let DsProtState::Unencrypted(result) = &self.dsprot_state {
+                Ok(Some(result))
+            } else {
+                unreachable!();
+            }
+        } else {
+            let dsprot_info = if self.is_compressed() {
+                return overlay_ds_prot_error::CompressedSnafu.fail();
+            } else if let Some(dsprot_info) = DsProtInfo::detect(&self.data) {
+                dsprot_info
+            } else {
+                // DS Protect is not used
+                return Ok(None);
+            };
 
-        let base_address = self.base_address();
-        let result = dsprot_info.decrypt(self.data.to_mut(), base_address, options)?;
-        self.dsprot_state = DsProtState::Unencrypted(result);
-        let DsProtState::Unencrypted(result) = &self.dsprot_state else { unreachable!() };
-        Ok(Some(result))
+            let base_address = self.base_address();
+            let result = dsprot_info.decrypt(self.data.to_mut(), base_address, options)?;
+            self.dsprot_state = DsProtState::Unencrypted(result);
+            let DsProtState::Unencrypted(result) = &self.dsprot_state else { unreachable!() };
+            Ok(Some(result))
+        }
     }
 
     /// Encrypts DS Protect functions in this overlay. This can only be done if

--- a/lib/src/rom/overlay.rs
+++ b/lib/src/rom/overlay.rs
@@ -10,20 +10,21 @@ use super::{
 use crate::{
     compress::lz77::{Lz77, Lz77DecompressError},
     crypto::{
-        dsprot::{DecryptOptions, DsProtDecryptDetails, DsProtError, DsProtInfo},
+        dsprot::{DecryptOptions, DsProtDecryptResult, DsProtError, DsProtInfo, DsProtState},
         hmac_sha1::HmacSha1,
     },
     rom::Arm9HmacSha1KeyError,
 };
 
 /// An overlay module for ARM9/ARM7.
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub struct Overlay<'a> {
     originally_compressed: bool,
     originally_signed: bool,
     info: OverlayInfo,
     signature: Option<HmacSha1Signature>,
     data: Cow<'a, [u8]>,
+    dsprot_state: DsProtState,
 }
 
 const LZ77: Lz77 = Lz77 {};
@@ -36,6 +37,8 @@ pub struct OverlayOptions {
     pub originally_signed: bool,
     /// Overlay info.
     pub info: OverlayInfo,
+    /// DS Protect decryption info, used for re-encrypting DS Protect functions.
+    pub dsprot: Option<DsProtDecryptResult>,
 }
 
 /// Errors related to [`Overlay`].
@@ -100,10 +103,12 @@ pub enum OverlayDsProtError {
 impl<'a> Overlay<'a> {
     /// Creates a new [`Overlay`] from plain data.
     pub fn new<T: Into<Cow<'a, [u8]>>>(data: T, options: OverlayOptions) -> Result<Self, OverlayError> {
-        let OverlayOptions { originally_compressed, originally_signed, info } = options;
+        let OverlayOptions { originally_compressed, originally_signed, info, dsprot } = options;
         let data = data.into();
 
-        Ok(Self { originally_compressed, originally_signed, info, signature: None, data })
+        let dsprot_state = if let Some(dsprot) = dsprot { DsProtState::Encrypted(dsprot) } else { DsProtState::None };
+
+        Ok(Self { originally_compressed, originally_signed, info, signature: None, data, dsprot_state })
     }
 
     /// Parses an ARM9 [`Overlay`] from a ROM.
@@ -123,6 +128,7 @@ impl<'a> Overlay<'a> {
             info: OverlayInfo::new(overlay),
             signature: None,
             data: Cow::Borrowed(data),
+            dsprot_state: DsProtState::None,
         };
 
         if overlay.flags.is_signed() {
@@ -165,6 +171,7 @@ impl<'a> Overlay<'a> {
             info: OverlayInfo::new(overlay),
             signature: None,
             data: Cow::Borrowed(data),
+            dsprot_state: DsProtState::None,
         };
 
         Ok(overlay)
@@ -331,26 +338,57 @@ impl<'a> Overlay<'a> {
         if self.is_compressed() { overlay_ds_prot_error::CompressedSnafu.fail() } else { Ok(DsProtInfo::detect(&self.data)) }
     }
 
-    /// Decrypts all functions in this overlay that were encrypted by DS Protect.
+    /// Decrypts all functions in this overlay that were encrypted by DS Protect. Does nothing if
+    /// [`Overlay::dsprot_state`] is [`DsProtState::Unencrypted`].
     ///
     /// # Errors
     ///
     /// This function will return an error if [`DsProtInfo::decrypt`] fails.
-    pub fn decrypt_dsprot(&mut self, options: &DecryptOptions) -> Result<Option<DsProtDecryptDetails>, OverlayDsProtError> {
+    pub fn decrypt_dsprot(&mut self, options: &DecryptOptions) -> Result<Option<&DsProtDecryptResult>, OverlayDsProtError> {
         let Some(dsprot_info) = self.dsprot_info()? else {
             // DS Protect is not used
             return Ok(None);
         };
 
         let base_address = self.base_address();
-        let details = dsprot_info.decrypt(self.data.to_mut(), base_address, options)?;
+        let result = dsprot_info.decrypt(self.data.to_mut(), base_address, options)?;
+        self.dsprot_state = DsProtState::Unencrypted(result);
+        let DsProtState::Unencrypted(result) = &self.dsprot_state else { unreachable!() };
+        Ok(Some(result))
+    }
 
-        Ok(Some(details))
+    /// Encrypts DS Protect functions in this overlay. This can only be done if
+    /// [`Overlay::dsprot_state`] is [`DsProtState::Unencrypted`].
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if [`DsProtInfo::decrypt`] fails.
+    pub fn encrypt_dsprot(&mut self) -> Result<(), OverlayDsProtError> {
+        let dsprot_state = std::mem::replace(&mut self.dsprot_state, DsProtState::None);
+        let DsProtState::Unencrypted(dsprot_result) = dsprot_state else {
+            self.dsprot_state = dsprot_state; // revert replace
+            return Ok(());
+        };
+
+        let base_address = self.base_address();
+        dsprot_result.encrypt(self.data.to_mut(), base_address)?;
+        self.dsprot_state = DsProtState::Encrypted(dsprot_result);
+
+        Ok(())
+    }
+
+    /// Returns the [`DsProtState`] of this overlay.
+    pub fn dsprot_state(&self) -> &DsProtState {
+        &self.dsprot_state
+    }
+
+    pub(crate) fn set_dsprot_state(&mut self, dsprot_state: DsProtState) {
+        self.dsprot_state = dsprot_state;
     }
 }
 
 /// Info of an [`Overlay`], similar to an entry in the overlay table.
-#[derive(Serialize, Deserialize, Clone)]
+#[derive(Serialize, Deserialize, Clone, PartialEq, Eq)]
 pub struct OverlayInfo {
     /// Overlay ID.
     pub id: u32,

--- a/lib/src/rom/overlay_table.rs
+++ b/lib/src/rom/overlay_table.rs
@@ -1,6 +1,6 @@
 use super::{
-    raw::{self, HmacSha1Signature},
     Arm9, Overlay, OverlayError,
+    raw::{self, HmacSha1Signature},
 };
 use crate::crypto::hmac_sha1::HmacSha1;
 

--- a/lib/src/rom/raw/arm9_footer.rs
+++ b/lib/src/rom/raw/arm9_footer.rs
@@ -6,7 +6,7 @@ use std::{
 use bytemuck::{Pod, PodCastError, Zeroable};
 use snafu::{Backtrace, Snafu};
 
-use super::{RawHeaderError, NITROCODE};
+use super::{NITROCODE, RawHeaderError};
 
 /// Footer of the ARM9 program.
 #[repr(C)]

--- a/lib/src/rom/raw/build_info.rs
+++ b/lib/src/rom/raw/build_info.rs
@@ -6,7 +6,7 @@ use std::{
 use bytemuck::{Pod, PodCastError, Zeroable};
 use snafu::{Backtrace, Snafu};
 
-use super::{RawHeaderError, NITROCODE};
+use super::{NITROCODE, RawHeaderError};
 
 /// Build info for the ARM9 module. This is the raw version, see the plain one [here](super::super::BuildInfo).
 #[repr(C)]

--- a/lib/src/rom/raw/fnt.rs
+++ b/lib/src/rom/raw/fnt.rs
@@ -68,11 +68,7 @@ pub enum RawFntError {
 impl<'a> Fnt<'a> {
     fn check_size(data: &'_ [u8]) -> Result<(), RawFntError> {
         let size = size_of::<FntDirectory>();
-        if data.len() < size {
-            InvalidSizeSnafu {}.fail()
-        } else {
-            Ok(())
-        }
+        if data.len() < size { InvalidSizeSnafu {}.fail() } else { Ok(()) }
     }
 
     fn handle_pod_cast<T>(result: Result<T, PodCastError>) -> T {

--- a/lib/src/rom/raw/multiboot_signature.rs
+++ b/lib/src/rom/raw/multiboot_signature.rs
@@ -1,6 +1,6 @@
 use std::{backtrace::Backtrace, fmt::Display};
 
-use bytemuck::{Pod, PodCastError, Zeroable};
+use bytemuck::{Pod, Zeroable};
 use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 
@@ -38,16 +38,6 @@ pub enum RawMultibootSignatureError {
         /// Backtrace to the source of the error.
         backtrace: Backtrace,
     },
-    /// Occurs when the input is less aligned than [`MultibootSignature`].
-    #[snafu(display("expected {expected}-alignment but got {actual}-alignment:\n{backtrace}"))]
-    Misaligned {
-        /// Expected alignment.
-        expected: usize,
-        /// Actual alignment.
-        actual: usize,
-        /// Backtrace to the source of the error.
-        backtrace: Backtrace,
-    },
     /// Occurs when the magic number does not match [`MULTIBOOT_SIGNATURE_MAGIC`].
     #[snafu(display("expected magic number {expected:#010x} but got {actual:#010x}:\n{backtrace}"))]
     InvalidMagic {
@@ -70,28 +60,19 @@ impl MultibootSignature {
         }
     }
 
-    fn handle_pod_cast<T>(result: Result<T, PodCastError>, addr: usize) -> Result<T, RawMultibootSignatureError> {
-        match result {
-            Ok(build_info) => Ok(build_info),
-            Err(PodCastError::TargetAlignmentGreaterAndInputNotAligned) => {
-                MisalignedSnafu { expected: align_of::<Self>(), actual: 1usize << addr.trailing_zeros() }.fail()
-            }
-            Err(PodCastError::AlignmentMismatch) => panic!(),
-            Err(PodCastError::OutputSliceWouldHaveSlop) => panic!(),
-            Err(PodCastError::SizeMismatch) => unreachable!(),
-        }
-    }
-
-    /// Reinterprets a `&[u8]` as a reference to [`MultibootSignature`].
+    /// Creates a [`MultibootSignature`] from `&[u8]`.
     ///
     /// # Errors
     ///
-    /// This function will return an error if the input is too small or not aligned enough.
-    pub fn borrow_from_slice(data: &[u8]) -> Result<&Self, RawMultibootSignatureError> {
+    /// This function will return an error if the input is too small or has the wrong magic header.
+    pub fn from_slice(data: &[u8]) -> Result<Self, RawMultibootSignatureError> {
         let size = size_of::<Self>();
         Self::check_size(data)?;
-        let addr = data as *const [u8] as *const () as usize;
-        let multiboot_signature: &Self = Self::handle_pod_cast(bytemuck::try_from_bytes(&data[..size]), addr)?;
+
+        let mut multiboot_signature = Self::zeroed();
+        let signature_bytes = bytemuck::bytes_of_mut(&mut multiboot_signature);
+        signature_bytes.copy_from_slice(&data[..size]);
+
         if multiboot_signature.magic != MULTIBOOT_SIGNATURE_MAGIC {
             return InvalidMagicSnafu { expected: MULTIBOOT_SIGNATURE_MAGIC, actual: multiboot_signature.magic }.fail();
         }

--- a/lib/src/rom/raw/rom.rs
+++ b/lib/src/rom/raw/rom.rs
@@ -311,14 +311,13 @@ impl<'a> Rom<'a> {
     /// # Errors
     ///
     /// See [`Self::header`] and [`MultibootSignature::borrow_from_slice`].
-    pub fn multiboot_signature(&self) -> Result<Option<&MultibootSignature>, RawMultibootSignatureError> {
+    pub fn multiboot_signature(&self) -> Result<Option<MultibootSignature>, RawMultibootSignatureError> {
         let header = self.header()?;
         let start = header.rom_size_ds as usize;
         let data = &self.data[start..];
-        match MultibootSignature::borrow_from_slice(data) {
+        match MultibootSignature::from_slice(data) {
             Ok(s) => Ok(Some(s)),
             Err(RawMultibootSignatureError::InvalidMagic { .. }) => Ok(None), // signature not found
-            Err(RawMultibootSignatureError::Misaligned { .. }) => Ok(None),   // not aligned by 4
             Err(e) => Err(e),
         }
     }

--- a/lib/src/rom/raw/rom.rs
+++ b/lib/src/rom/raw/rom.rs
@@ -217,8 +217,11 @@ impl<'a> Rom<'a> {
         let end = start + header.arm7.size as usize;
         let data = &self.data[start..end];
 
-        let build_info_offset =
-            if header.arm7_build_info_offset == 0 { 0 } else { header.arm7_build_info_offset - header.arm7.offset };
+        let build_info_offset = if header.arm7_build_info_offset == 0 {
+            0
+        } else {
+            header.arm7_build_info_offset - header.arm7.offset
+        };
 
         Ok(Arm7::new(Cow::Borrowed(data), Arm7Offsets {
             base_address: header.arm7.base_addr,
@@ -430,7 +433,11 @@ impl<'a> Rom<'a> {
 
         // Get the alignment of the current section, by looking at the address of the next section.
         fn get_alignment(next_section: u32) -> u32 {
-            if next_section.trailing_zeros() >= 9 { 0x200 } else { DEFAULT_ALIGNMENT }
+            if next_section.trailing_zeros() >= 9 {
+                0x200
+            } else {
+                DEFAULT_ALIGNMENT
+            }
         }
 
         let fat = self.fat()?;

--- a/lib/src/rom/raw/rom.rs
+++ b/lib/src/rom/raw/rom.rs
@@ -7,10 +7,10 @@ use super::{
     RawFatError, RawFntError, RawHeaderError, RawOverlayError,
 };
 use crate::{
-    io::{open_file, write_file, FileError},
+    io::{FileError, open_file, write_file},
     rom::{
+        Arm7, Arm7Offsets, Arm9, Arm9Offsets, RomConfigAlignment, RomConfigPaddingValues,
         raw::{MultibootSignature, RawMultibootSignatureError},
-        Arm7, Arm7Offsets, Arm9, Arm9Offsets, RomConfigAlignment,
     },
 };
 
@@ -323,12 +323,62 @@ impl<'a> Rom<'a> {
         }
     }
 
+    /// Returns the padding values between ROM sections.
+    ///
+    /// # Errors
+    ///
+    /// See [`Self::header`], [`Self::fat`], [`Self::arm9_overlays`], [`Self::arm7_overlays`] and
+    /// [`Self::file_image_padding_value`].
+    pub fn padding_values(&self) -> Result<RomConfigPaddingValues, RomAlignmentsError> {
+        let header = self.header()?;
+        let fat = self.fat()?;
+        let arm9_overlays = self.arm9_overlays()?;
+        let arm7_overlays = self.arm7_overlays()?;
+
+        Ok(RomConfigPaddingValues {
+            arm9: self.data[header.arm9.offset as usize - 1],
+            arm9_overlay_table: if header.arm9_overlays.offset > 0 {
+                self.data[header.arm9_overlays.offset as usize - 1]
+            } else {
+                DEFAULT_PADDING_VALUE
+            },
+            arm9_overlays: self.get_overlays_padding(arm9_overlays, fat).unwrap_or(DEFAULT_PADDING_VALUE),
+            arm7: self.data[header.arm7.offset as usize - 1],
+            arm7_overlay_table: if header.arm7_overlays.offset > 0 {
+                self.data[header.arm7_overlays.offset as usize - 1]
+            } else {
+                DEFAULT_PADDING_VALUE
+            },
+            arm7_overlays: self.get_overlays_padding(arm7_overlays, fat).unwrap_or(DEFAULT_PADDING_VALUE),
+            fnt: self.data[header.file_names.offset as usize - 1],
+            fat: self.data[header.file_allocs.offset as usize - 1],
+            banner: self.data[header.banner_offset as usize - 1],
+            file_image: self.file_image_padding_value()?,
+            rom: *self.data.last().unwrap_or(&DEFAULT_PADDING_VALUE),
+        })
+    }
+
+    fn get_overlays_padding(&self, overlays: &[Overlay], fat: &[FileAlloc]) -> Option<u8> {
+        let mut overlay_files = overlays.iter().map(|o| &fat[o.id as usize]).collect::<Vec<_>>();
+        overlay_files.sort_unstable_by_key(|o| o.start);
+        let mut overlay_files = overlay_files.into_iter();
+        if let Some(mut prev_overlay) = overlay_files.next() {
+            for overlay in overlay_files {
+                if prev_overlay.end != overlay.start {
+                    return Some(self.data[overlay.start as usize - 1]);
+                }
+                prev_overlay = overlay;
+            }
+        }
+        None
+    }
+
     /// Returns the padding value in the file image block of this [`Rom`].
     ///
     /// # Errors
     ///
     /// See [`Self::fat`], [`Self::arm9_overlays`] and [`Self::arm7_overlays`].
-    pub fn file_image_padding_value(&self) -> Result<u8, RomAlignmentsError> {
+    fn file_image_padding_value(&self) -> Result<u8, RomAlignmentsError> {
         let fat = self.fat()?;
         let arm9_overlays = self.arm9_overlays()?;
         let arm7_overlays = self.arm7_overlays()?;
@@ -346,49 +396,8 @@ impl<'a> Rom<'a> {
 
         // Find a gap between two adjacent files, and return the padding byte between them
         let Some(gap) = files.windows(2).find(|pair| pair[0].end != pair[1].start) else {
-            return Ok(0xff);
+            return Ok(DEFAULT_PADDING_VALUE);
         };
-        Ok(self.data[gap[0].end as usize])
-    }
-
-    /// Returns the section padding value of this [`Rom`].
-    ///
-    /// # Errors
-    ///
-    /// See [`Self::header`], [`Self::banner`], [`Self::fat`], [`Self::arm9_overlays`] and [`Self::arm7_overlays`].
-    pub fn section_padding_value(&self) -> Result<u8, RomAlignmentsError> {
-        let header = self.header()?;
-        let banner = self.banner()?;
-        let fat = self.fat()?;
-        let arm9_overlays = self.arm9_overlays()?;
-        let arm7_overlays = self.arm7_overlays()?;
-
-        // Get sorted list of adjacent sections in the ROM
-        let mut sections = vec![
-            header.arm9.offset..header.arm9.offset + header.arm9.size + size_of::<Arm9Footer>() as u32,
-            header.arm7.offset..header.arm7.offset + header.arm7.size,
-            header.file_names.offset..header.file_names.offset + header.file_names.size,
-            header.file_allocs.offset..header.file_allocs.offset + header.file_allocs.size,
-            header.arm9_overlays.offset..header.arm9_overlays.offset + header.arm9_overlays.size,
-            header.arm7_overlays.offset..header.arm7_overlays.offset + header.arm7_overlays.size,
-        ];
-        sections.push(header.banner_offset..header.banner_offset + banner.version().banner_size() as u32);
-        arm9_overlays.iter().for_each(|overlay| {
-            let file = &fat[overlay.file_id as usize];
-            sections.push(file.start..file.end);
-        });
-        arm7_overlays.iter().for_each(|overlay| {
-            let file = &fat[overlay.file_id as usize];
-            sections.push(file.start..file.end);
-        });
-        sections.retain(|section| section.start != section.end);
-        sections.sort_by_key(|section| section.start);
-
-        // Find a gap between two adjacent sections, and return the padding byte between them
-        let Some(gap) = sections.windows(2).find(|pair| pair[0].end != pair[1].start) else {
-            return Ok(0xff);
-        };
-        log::debug!("Gap between sections: {:#010x} - {:#010x}", gap[0].end, gap[1].start);
         Ok(self.data[gap[0].end as usize])
     }
 
@@ -421,11 +430,7 @@ impl<'a> Rom<'a> {
 
         // Get the alignment of the current section, by looking at the address of the next section.
         fn get_alignment(next_section: u32) -> u32 {
-            if next_section.trailing_zeros() >= 9 {
-                0x200
-            } else {
-                DEFAULT_ALIGNMENT
-            }
+            if next_section.trailing_zeros() >= 9 { 0x200 } else { DEFAULT_ALIGNMENT }
         }
 
         let fat = self.fat()?;
@@ -477,3 +482,5 @@ impl<'a> Rom<'a> {
         })
     }
 }
+
+const DEFAULT_PADDING_VALUE: u8 = 0xff;

--- a/lib/src/rom/rom.rs
+++ b/lib/src/rom/rom.rs
@@ -715,7 +715,7 @@ impl<'a> Rom<'a> {
 
         let has_arm9_hmac_sha1 = decompressed_arm9.hmac_sha1_key()?.is_some();
 
-        let multiboot_signature = rom.multiboot_signature()?.cloned();
+        let multiboot_signature = rom.multiboot_signature()?;
 
         let alignment = rom.alignments()?;
 

--- a/lib/src/rom/rom.rs
+++ b/lib/src/rom/rom.rs
@@ -476,7 +476,11 @@ impl<'a> Rom<'a> {
             let data = read_file(path.join(config.file_name))?;
             let compressed = config.info.compressed;
             config.info.compressed = false;
-            let mut overlay = Overlay::new(data, OverlayOptions { info: config.info, originally_compressed: compressed })?;
+            let mut overlay = Overlay::new(data, OverlayOptions {
+                info: config.info,
+                originally_compressed: compressed,
+                originally_signed: config.signed,
+            })?;
 
             if options.compress {
                 if compressed {

--- a/lib/src/rom/rom.rs
+++ b/lib/src/rom/rom.rs
@@ -800,12 +800,24 @@ impl<'a> Rom<'a> {
             itcm: RomConfigAutoload { bin: "arm9/itcm.bin".into(), config: "arm9/itcm.yaml".into() },
             unknown_autoloads,
             dtcm: RomConfigAutoload { bin: "arm9/dtcm.bin".into(), config: "arm9/dtcm.yaml".into() },
-            arm9_overlays: if arm9_overlays.is_empty() { None } else { Some("arm9_overlays/overlays.yaml".into()) },
-            arm7_overlays: if arm7_overlays.is_empty() { None } else { Some("arm7_overlays/overlays.yaml".into()) },
+            arm9_overlays: if arm9_overlays.is_empty() {
+                None
+            } else {
+                Some("arm9_overlays/overlays.yaml".into())
+            },
+            arm7_overlays: if arm7_overlays.is_empty() {
+                None
+            } else {
+                Some("arm7_overlays/overlays.yaml".into())
+            },
             banner: "banner/banner.yaml".into(),
             files_dir: "files/".into(),
             path_order: "path_order.txt".into(),
-            multiboot_signature: if multiboot_signature.is_none() { None } else { Some("multiboot_signature.yaml".into()) },
+            multiboot_signature: if multiboot_signature.is_none() {
+                None
+            } else {
+                Some("multiboot_signature.yaml".into())
+            },
             arm9_hmac_sha1_key: has_arm9_hmac_sha1.then_some("arm9/hmac_sha1_key.bin".into()),
             alignment,
             padding,

--- a/lib/src/rom/rom.rs
+++ b/lib/src/rom/rom.rs
@@ -22,7 +22,7 @@ use crate::{
     compress::lz77::Lz77DecompressError,
     crypto::{
         blowfish::BlowfishKey,
-        dsprot::{DecryptOptions, DsProtDecryptResult, DsProtState},
+        dsprot::{DsProtDecryptOptions, DsProtDecryptResult, DsProtState},
         hmac_sha1::{HmacSha1, HmacSha1FromBytesError},
     },
     io::{FileError, create_dir_all, create_file, create_file_and_dirs, open_file, read_file, read_to_string},
@@ -754,7 +754,7 @@ impl<'a> Rom<'a> {
         // Decrypt DS Protect functions in ARM9 program and overlays. This stores a
         // DsProtDecryptResult on those that were decrypted, which can be serialized to arm9.yaml
         // or overlays.yaml.
-        let dsprot_options = DecryptOptions { decode_literals: true };
+        let dsprot_options = DsProtDecryptOptions { decode_relocations: true };
         if let Some(result) = decompressed_arm9.decrypt_dsprot(&dsprot_options)? {
             arm9.set_dsprot_state(DsProtState::Encrypted(result.clone()));
         }

--- a/lib/src/rom/rom.rs
+++ b/lib/src/rom/rom.rs
@@ -581,8 +581,6 @@ impl<'a> Rom<'a> {
         self.header_logo.save_png(path.join(&self.config.header_logo))?;
 
         // --------------------- Save ARM9 program ---------------------
-        let arm9_build_config = self.arm9_build_config()?;
-        serde_saphyr::to_io_writer(&mut create_file_and_dirs(path.join(&self.config.arm9_config))?, &arm9_build_config)?;
         let mut plain_arm9 = self.arm9.clone();
         if plain_arm9.is_encrypted() {
             let Some(key) = key else {
@@ -600,6 +598,14 @@ impl<'a> Rom<'a> {
             plain_arm9.decrypt_dsprot(&DsProtDecryptOptions::default())?;
         }
         create_file_and_dirs(path.join(&self.config.arm9_bin))?.write_all(plain_arm9.code()?)?;
+        let arm9_build_config = Arm9BuildConfig {
+            offsets: *self.arm9.offsets(),
+            encrypted: self.arm9.is_encrypted(),
+            compressed: self.arm9.is_compressed()?,
+            build_info: (*self.arm9.build_info()?).into(),
+            dsprot_state: plain_arm9.dsprot_state().clone(),
+        };
+        serde_saphyr::to_io_writer(&mut create_file_and_dirs(path.join(&self.config.arm9_config))?, &arm9_build_config)?;
 
         // --------------------- Save ARM9 HMAC-SHA1 key ---------------------
         if let Some(arm9_hmac_sha1_key) = plain_arm9.hmac_sha1_key()? {
@@ -682,17 +688,6 @@ impl<'a> Rom<'a> {
         }
 
         Ok(())
-    }
-
-    /// Generates a build config for ARM9, which normally goes into arm9.yaml.
-    pub fn arm9_build_config(&self) -> Result<Arm9BuildConfig, RomSaveError> {
-        Ok(Arm9BuildConfig {
-            offsets: *self.arm9.offsets(),
-            encrypted: self.arm9.is_encrypted(),
-            compressed: self.arm9.is_compressed()?,
-            build_info: (*self.arm9.build_info()?).into(),
-            dsprot_state: self.arm9.dsprot_state().clone(),
-        })
     }
 
     fn save_overlays(config_path: &Path, overlay_table: &OverlayTable, processor: &str) -> Result<(), RomSaveError> {

--- a/lib/src/rom/rom.rs
+++ b/lib/src/rom/rom.rs
@@ -22,7 +22,7 @@ use crate::{
     compress::lz77::Lz77DecompressError,
     crypto::{
         blowfish::BlowfishKey,
-        dsprot::{DsProtDecryptOptions, DsProtDecryptResult, DsProtState},
+        dsprot::{DsProtDecryptOptions, DsProtEncryptOptions, DsProtState},
         hmac_sha1::{HmacSha1, HmacSha1FromBytesError},
     },
     io::{FileError, create_dir_all, create_file, create_file_and_dirs, open_file, read_file, read_to_string},
@@ -300,6 +300,18 @@ pub enum RomSaveError {
         /// Backtrace to the source of the error.
         backtrace: Backtrace,
     },
+    /// See [`Arm9DsProtInfoError`].
+    #[snafu(transparent)]
+    Arm9DsProtInfo {
+        /// Source error.
+        source: Arm9DsProtInfoError,
+    },
+    /// See [`OverlayDsProtError`].
+    #[snafu(transparent)]
+    OverlayDsProt {
+        /// Source error.
+        source: OverlayDsProtError,
+    },
 }
 
 /// Config file for the ARM9 main module.
@@ -316,7 +328,8 @@ pub struct Arm9BuildConfig {
     #[serde(flatten)]
     pub build_info: BuildInfo,
     /// Information about DS Protect.
-    pub dsprot: Option<DsProtDecryptResult>,
+    #[serde(default, skip_serializing_if = "DsProtState::is_none")]
+    pub dsprot_state: DsProtState,
 }
 
 /// Overlay configuration, extending [`OverlayInfo`] with more fields.
@@ -330,8 +343,8 @@ pub struct OverlayConfig {
     /// Name of binary file.
     pub file_name: String,
     /// Stores information about DS Protect functions that were decrypted in this overlay.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub dsprot: Option<DsProtDecryptResult>,
+    #[serde(default, skip_serializing_if = "DsProtState::is_none")]
+    pub dsprot: DsProtState,
 }
 
 /// Configuration for the overlay table, used for both ARM9 and ARM7 overlays.
@@ -414,10 +427,14 @@ impl<'a> Rom<'a> {
         let mut arm9 = Arm9::with_autoloads(arm9, &autoloads, arm9_build_config.offsets, Arm9WithTcmsOptions {
             originally_compressed: arm9_build_config.compressed,
             originally_encrypted: arm9_build_config.encrypted,
-            dsprot: arm9_build_config.dsprot,
+            dsprot_state: arm9_build_config.dsprot_state,
         })?;
         arm9_build_config.build_info.assign_to_raw(arm9.build_info_mut()?);
         arm9.update_overlay_signatures(&arm9_overlays)?;
+        if arm9.dsprot_state().is_unencrypted() && options.encrypt {
+            log::info!("Encrypting DS Protect in ARM9 program");
+            arm9.encrypt_dsprot(&DsProtEncryptOptions::default())?;
+        }
         if arm9_build_config.compressed && options.compress {
             log::info!("Compressing ARM9 program");
             arm9.compress()?;
@@ -505,8 +522,13 @@ impl<'a> Rom<'a> {
                 info: config.info,
                 originally_compressed: compressed,
                 originally_signed: config.signed,
-                dsprot: config.dsprot,
+                dsprot_state: config.dsprot,
             })?;
+
+            if overlay.dsprot_state().is_unencrypted() && options.encrypt {
+                log::info!("Encrypting DS Protect in {processor} overlay {}", overlay.id());
+                overlay.encrypt_dsprot(&DsProtEncryptOptions::default())?;
+            }
 
             if options.compress {
                 if compressed {
@@ -572,6 +594,10 @@ impl<'a> Rom<'a> {
         if plain_arm9.is_compressed()? {
             log::info!("Decompressing ARM9 program");
             plain_arm9.decompress()?;
+        }
+        if plain_arm9.dsprot_state().is_encrypted() {
+            log::info!("Decrypting DS Protect in ARM9 program");
+            plain_arm9.decrypt_dsprot(&DsProtDecryptOptions::default())?;
         }
         create_file_and_dirs(path.join(&self.config.arm9_bin))?.write_all(plain_arm9.code()?)?;
 
@@ -665,7 +691,7 @@ impl<'a> Rom<'a> {
             encrypted: self.arm9.is_encrypted(),
             compressed: self.arm9.is_compressed()?,
             build_info: (*self.arm9.build_info()?).into(),
-            dsprot: self.arm9.dsprot_state().as_option().cloned(),
+            dsprot_state: self.arm9.dsprot_state().clone(),
         })
     }
 
@@ -680,17 +706,22 @@ impl<'a> Rom<'a> {
                 let name = format!("ov{:03}", overlay.id());
 
                 let mut plain_overlay = overlay.clone();
-                configs.push(OverlayConfig {
-                    info: plain_overlay.info().clone(),
-                    file_name: format!("{name}.bin"),
-                    signed: overlay.is_signed(),
-                    dsprot: overlay.dsprot_state().as_option().cloned(),
-                });
-
                 if plain_overlay.is_compressed() {
                     log::info!("Decompressing {processor} overlay {}/{}", overlay.id(), overlays.len() - 1);
                     plain_overlay.decompress()?;
                 }
+                if plain_overlay.dsprot_state().is_encrypted() {
+                    log::info!("Decrypting DS Protect in {processor} overlay {}", overlay.id());
+                    plain_overlay.decrypt_dsprot(&DsProtDecryptOptions { decode_relocations: false })?;
+                }
+
+                configs.push(OverlayConfig {
+                    info: overlay.info().clone(),
+                    file_name: format!("{name}.bin"),
+                    signed: plain_overlay.is_signed(),
+                    dsprot: plain_overlay.dsprot_state().clone(),
+                });
+
                 create_file(overlays_path.join(format!("{name}.bin")))?.write_all(plain_overlay.code())?;
             }
 
@@ -751,10 +782,7 @@ impl<'a> Rom<'a> {
 
         let alignment = rom.alignments()?;
 
-        // Decrypt DS Protect functions in ARM9 program and overlays. This stores a
-        // DsProtDecryptResult on those that were decrypted, which can be serialized to arm9.yaml
-        // or overlays.yaml.
-        let dsprot_options = DsProtDecryptOptions { decode_relocations: true };
+        let dsprot_options = DsProtDecryptOptions::default();
         if let Some(result) = decompressed_arm9.decrypt_dsprot(&dsprot_options)? {
             arm9.set_dsprot_state(DsProtState::Encrypted(result.clone()));
         }
@@ -1083,7 +1111,8 @@ pub struct RomLoadOptions<'a> {
     pub key: Option<&'a BlowfishKey>,
     /// If true (default), compress ARM9 and overlays if they are configured with `compressed: true`.
     pub compress: bool,
-    /// If true (default), encrypt ARM9 if it's configured with `encrypted: true`.
+    /// If true (default), encrypt ARM9 if it's configured with `encrypted: true`, and ARM9/overlays
+    /// if they contain DS Protect.
     pub encrypt: bool,
     /// If true (default), load asset files.
     pub load_files: bool,

--- a/lib/src/rom/rom.rs
+++ b/lib/src/rom/rom.rs
@@ -781,6 +781,7 @@ impl<'a> Rom<'a> {
         let multiboot_signature = rom.multiboot_signature()?;
 
         let alignment = rom.alignments()?;
+        let padding = rom.padding_values()?;
 
         let dsprot_options = DsProtDecryptOptions::default();
         if let Some(result) = decompressed_arm9.decrypt_dsprot(&dsprot_options)? {
@@ -795,8 +796,6 @@ impl<'a> Rom<'a> {
         }
 
         let config = RomConfig {
-            file_image_padding_value: rom.file_image_padding_value()?,
-            section_padding_value: rom.section_padding_value()?,
             header: "header.yaml".into(),
             header_logo: "header_logo.png".into(),
             arm9_bin: "arm9/arm9.bin".into(),
@@ -814,6 +813,7 @@ impl<'a> Rom<'a> {
             multiboot_signature: if multiboot_signature.is_none() { None } else { Some("multiboot_signature.yaml".into()) },
             arm9_hmac_sha1_key: has_arm9_hmac_sha1.then_some("arm9/hmac_sha1_key.bin".into()),
             alignment,
+            padding,
         };
 
         Ok(Self {
@@ -846,7 +846,7 @@ impl<'a> Rom<'a> {
         cursor.write_all(&[0u8; size_of::<raw::Header>()])?;
 
         // --------------------- Write ARM9 program ---------------------
-        self.align_section(&mut cursor, self.config.alignment.arm9)?;
+        self.align(&mut cursor, self.config.alignment.arm9, self.config.padding.arm9)?;
         context.arm9_offset = Some(cursor.position() as u32);
         context.arm9_autoload_callback = Some(self.arm9.autoload_callback());
         context.arm9_build_info_offset = Some(self.arm9.build_info_offset());
@@ -859,7 +859,7 @@ impl<'a> Rom<'a> {
 
         if !self.arm9_overlay_table.is_empty() {
             // --------------------- Write ARM9 overlay table ---------------------
-            self.align_section(&mut cursor, self.config.alignment.arm9_overlay_table)?;
+            self.align(&mut cursor, self.config.alignment.arm9_overlay_table, self.config.padding.arm9_overlay_table)?;
             context.arm9_ovt_offset = Some(TableOffset {
                 offset: cursor.position() as u32,
                 size: (self.arm9_overlay_table.len() * size_of::<raw::Overlay>()) as u32,
@@ -869,7 +869,7 @@ impl<'a> Rom<'a> {
 
             // --------------------- Write ARM9 overlays ---------------------
             for overlay in self.arm9_overlay_table.overlays() {
-                self.align_section(&mut cursor, self.config.alignment.arm9_overlay)?;
+                self.align(&mut cursor, self.config.alignment.arm9_overlay, self.config.padding.arm9_overlays)?;
                 let start = cursor.position() as u32;
                 let end = start + overlay.full_data().len() as u32;
                 file_allocs[overlay.file_id() as usize] = FileAlloc { start, end };
@@ -879,7 +879,7 @@ impl<'a> Rom<'a> {
         }
 
         // --------------------- Write ARM7 program ---------------------
-        self.align_section(&mut cursor, self.config.alignment.arm7)?;
+        self.align(&mut cursor, self.config.alignment.arm7, self.config.padding.arm7)?;
         context.arm7_offset = Some(cursor.position() as u32);
         context.arm7_autoload_callback = Some(self.arm7.autoload_callback());
         context.arm7_build_info_offset = None;
@@ -887,7 +887,7 @@ impl<'a> Rom<'a> {
 
         if !self.arm7_overlay_table.is_empty() {
             // --------------------- Write ARM7 overlay table ---------------------
-            self.align_section(&mut cursor, self.config.alignment.arm7_overlay_table)?;
+            self.align(&mut cursor, self.config.alignment.arm7_overlay_table, self.config.padding.arm7_overlay_table)?;
             context.arm7_ovt_offset = Some(TableOffset {
                 offset: cursor.position() as u32,
                 size: (self.arm7_overlay_table.len() * size_of::<raw::Overlay>()) as u32,
@@ -897,7 +897,7 @@ impl<'a> Rom<'a> {
 
             // --------------------- Write ARM7 overlays ---------------------
             for overlay in self.arm7_overlay_table.overlays() {
-                self.align_section(&mut cursor, self.config.alignment.arm7_overlay)?;
+                self.align(&mut cursor, self.config.alignment.arm7_overlay, self.config.padding.arm7_overlays)?;
                 let start = cursor.position() as u32;
                 let end = start + overlay.full_data().len() as u32;
                 file_allocs[overlay.file_id() as usize] = FileAlloc { start, end };
@@ -907,30 +907,31 @@ impl<'a> Rom<'a> {
         }
 
         // --------------------- Write file name table (FNT) ---------------------
-        self.align_section(&mut cursor, self.config.alignment.file_name_table)?;
+        self.align(&mut cursor, self.config.alignment.file_name_table, self.config.padding.fnt)?;
         self.files.sort_for_fnt();
         let fnt = self.files.build_fnt()?.build()?;
         context.fnt_offset = Some(TableOffset { offset: cursor.position() as u32, size: fnt.len() as u32 });
         cursor.write_all(&fnt)?;
 
         // --------------------- Write file allocation table (FAT) placeholder ---------------------
-        self.align_section(&mut cursor, self.config.alignment.file_allocation_table)?;
+        self.align(&mut cursor, self.config.alignment.file_allocation_table, self.config.padding.fat)?;
         context.fat_offset =
             Some(TableOffset { offset: cursor.position() as u32, size: (file_allocs.len() * size_of::<FileAlloc>()) as u32 });
         cursor.write_all(bytemuck::cast_slice(&file_allocs))?;
 
         // --------------------- Write banner ---------------------
-        self.align_section(&mut cursor, self.config.alignment.banner)?;
+        self.align(&mut cursor, self.config.alignment.banner, self.config.padding.banner)?;
         let banner = self.banner.build()?;
         context.banner_offset = Some(TableOffset { offset: cursor.position() as u32, size: banner.full_data().len() as u32 });
         cursor.write_all(banner.full_data())?;
 
         // --------------------- Write files ---------------------
-        self.align_file_image(&mut cursor, self.config.alignment.file_image_block)?;
+        self.align(&mut cursor, self.config.alignment.file_image_block, self.config.padding.file_image)?;
         self.files.sort_for_rom();
         self.files.traverse_files(self.path_order.iter().map(|s| s.as_str()), |file, _| {
             // TODO: Rewrite traverse_files as an iterator so these errors can be returned
-            self.align_file_image(&mut cursor, self.config.alignment.file).expect("failed to align after file");
+            self.align(&mut cursor, self.config.alignment.file, self.config.padding.file_image)
+                .expect("failed to align after file");
 
             let contents = file.contents();
             let start = cursor.position() as u32;
@@ -949,7 +950,7 @@ impl<'a> Rom<'a> {
 
         // --------------------- Write padding ---------------------
         let padded_rom_size = cursor.position().next_power_of_two().max(128 * 1024) as u32;
-        self.align_file_image(&mut cursor, padded_rom_size)?;
+        self.align(&mut cursor, padded_rom_size, self.config.padding.rom)?;
 
         // --------------------- Update FAT ---------------------
         cursor.set_position(context.fat_offset.unwrap().offset as u64);
@@ -971,14 +972,6 @@ impl<'a> Rom<'a> {
             cursor.write_all(&[padding_value])?;
         }
         Ok(())
-    }
-
-    fn align_section(&self, cursor: &mut Cursor<Vec<u8>>, alignment: u32) -> Result<(), RomBuildError> {
-        self.align(cursor, alignment, self.config.section_padding_value)
-    }
-
-    fn align_file_image(&self, cursor: &mut Cursor<Vec<u8>>, alignment: u32) -> Result<(), RomBuildError> {
-        self.align(cursor, alignment, self.config.file_image_padding_value)
     }
 
     /// Returns a reference to the header logo of this [`Rom`].

--- a/lib/src/rom/rom.rs
+++ b/lib/src/rom/rom.rs
@@ -9,25 +9,26 @@ use serde::{Deserialize, Serialize};
 use snafu::Snafu;
 
 use super::{
-    raw::{
-        self, Arm9Footer, HmacSha1Signature, RawArm9Error, RawBannerError, RawBuildInfoError, RawFatError, RawFntError,
-        RawHeaderError, RawOverlayError, RomAlignmentsError, TableOffset,
-    },
     Arm7, Arm9, Arm9AutoloadError, Arm9Error, Arm9HmacSha1KeyError, Arm9Offsets, Arm9OverlaySignaturesError, Autoload, Banner,
     BannerError, BannerImageError, BuildInfo, FileBuildError, FileParseError, FileSystem, Header, HeaderBuildError, Logo,
     LogoError, LogoLoadError, LogoSaveError, Overlay, OverlayError, OverlayInfo, OverlayOptions, OverlayTable,
     RomConfigAutoload, RomConfigUnknownAutoload,
+    raw::{
+        self, Arm9Footer, HmacSha1Signature, RawArm9Error, RawBannerError, RawBuildInfoError, RawFatError, RawFntError,
+        RawHeaderError, RawOverlayError, RomAlignmentsError, TableOffset,
+    },
 };
 use crate::{
     compress::lz77::Lz77DecompressError,
     crypto::{
         blowfish::BlowfishKey,
+        dsprot::{DecryptOptions, DsProtDecryptResult, DsProtState},
         hmac_sha1::{HmacSha1, HmacSha1FromBytesError},
     },
-    io::{create_dir_all, create_file, create_file_and_dirs, open_file, read_file, read_to_string, FileError},
+    io::{FileError, create_dir_all, create_file, create_file_and_dirs, open_file, read_file, read_to_string},
     rom::{
+        Arm9DsProtInfoError, Arm9WithTcmsOptions, OverlayDsProtError, RomConfig,
         raw::{FileAlloc, MultibootSignature, RawMultibootSignatureError},
-        Arm9WithTcmsOptions, RomConfig,
     },
 };
 
@@ -139,6 +140,24 @@ pub enum RomExtractError {
     RawMultibootSignature {
         /// Source error.
         source: RawMultibootSignatureError,
+    },
+    /// See [`Arm9DsProtInfoError`].
+    #[snafu(transparent)]
+    Arm9DsProtInfo {
+        /// Source error.
+        source: Arm9DsProtInfoError,
+    },
+    /// See [`OverlayDsProtError`].
+    #[snafu(transparent)]
+    OverlayDsProt {
+        /// Source error.
+        source: OverlayDsProtError,
+    },
+    /// See [`Lz77DecompressError`].
+    #[snafu(transparent)]
+    Lz77Decompress {
+        /// Source error.
+        source: Lz77DecompressError,
     },
 }
 
@@ -296,6 +315,8 @@ pub struct Arm9BuildConfig {
     /// Build info for this module.
     #[serde(flatten)]
     pub build_info: BuildInfo,
+    /// Information about DS Protect.
+    pub dsprot: Option<DsProtDecryptResult>,
 }
 
 /// Overlay configuration, extending [`OverlayInfo`] with more fields.
@@ -308,6 +329,9 @@ pub struct OverlayConfig {
     pub signed: bool,
     /// Name of binary file.
     pub file_name: String,
+    /// Stores information about DS Protect functions that were decrypted in this overlay.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub dsprot: Option<DsProtDecryptResult>,
 }
 
 /// Configuration for the overlay table, used for both ARM9 and ARM7 overlays.
@@ -390,6 +414,7 @@ impl<'a> Rom<'a> {
         let mut arm9 = Arm9::with_autoloads(arm9, &autoloads, arm9_build_config.offsets, Arm9WithTcmsOptions {
             originally_compressed: arm9_build_config.compressed,
             originally_encrypted: arm9_build_config.encrypted,
+            dsprot: arm9_build_config.dsprot,
         })?;
         arm9_build_config.build_info.assign_to_raw(arm9.build_info_mut()?);
         arm9.update_overlay_signatures(&arm9_overlays)?;
@@ -480,6 +505,7 @@ impl<'a> Rom<'a> {
                 info: config.info,
                 originally_compressed: compressed,
                 originally_signed: config.signed,
+                dsprot: config.dsprot,
             })?;
 
             if options.compress {
@@ -639,6 +665,7 @@ impl<'a> Rom<'a> {
             encrypted: self.arm9.is_encrypted(),
             compressed: self.arm9.is_compressed()?,
             build_info: (*self.arm9.build_info()?).into(),
+            dsprot: self.arm9.dsprot_state().as_option().cloned(),
         })
     }
 
@@ -657,6 +684,7 @@ impl<'a> Rom<'a> {
                     info: plain_overlay.info().clone(),
                     file_name: format!("{name}.bin"),
                     signed: overlay.is_signed(),
+                    dsprot: overlay.dsprot_state().as_option().cloned(),
                 });
 
                 if plain_overlay.is_compressed() {
@@ -691,12 +719,12 @@ impl<'a> Rom<'a> {
         let file_root = FileSystem::parse(&fnt, fat, rom)?;
         let path_order = file_root.compute_path_order();
 
-        let arm9 = rom.arm9()?;
+        let mut arm9 = rom.arm9()?;
         let mut decompressed_arm9 = arm9.clone();
         decompressed_arm9.decompress()?;
 
         let arm9_overlays = rom.arm9_overlay_table_with(&decompressed_arm9)?;
-        let arm9_overlays = OverlayTable::parse_arm9(arm9_overlays, rom, &decompressed_arm9)?;
+        let mut arm9_overlays = OverlayTable::parse_arm9(arm9_overlays, rom, &decompressed_arm9)?;
         let arm7_overlays = rom.arm7_overlay_table()?;
         let arm7_overlays = OverlayTable::parse_arm7(arm7_overlays, rom)?;
 
@@ -722,6 +750,21 @@ impl<'a> Rom<'a> {
         let multiboot_signature = rom.multiboot_signature()?;
 
         let alignment = rom.alignments()?;
+
+        // Decrypt DS Protect functions in ARM9 program and overlays. This stores a
+        // DsProtDecryptResult on those that were decrypted, which can be serialized to arm9.yaml
+        // or overlays.yaml.
+        let dsprot_options = DecryptOptions { decode_literals: true };
+        if let Some(result) = decompressed_arm9.decrypt_dsprot(&dsprot_options)? {
+            arm9.set_dsprot_state(DsProtState::Encrypted(result.clone()));
+        }
+        for overlay in arm9_overlays.overlays_mut() {
+            let mut decompressed_overlay = overlay.clone();
+            decompressed_overlay.decompress()?;
+            if let Some(result) = decompressed_overlay.decrypt_dsprot(&dsprot_options)? {
+                overlay.set_dsprot_state(DsProtState::Encrypted(result.clone()));
+            }
+        }
 
         let config = RomConfig {
             file_image_padding_value: rom.file_image_padding_value()?,

--- a/lib/src/str.rs
+++ b/lib/src/str.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, str::FromStr};
 
 use bytemuck::{Pod, Zeroable};
-use serde::{de, Deserialize, Serialize};
+use serde::{Deserialize, Serialize, de};
 use snafu::{Backtrace, Snafu};
 
 /// A fixed-size ASCII string.

--- a/lib/tests/common.rs
+++ b/lib/tests/common.rs
@@ -29,7 +29,11 @@ impl RomsTest {
                 Err(e) => return Some(Err(anyhow!(e))),
             };
             let path = entry.path();
-            if path.extension() != Some(OsStr::new("nds")) { None } else { Some(Ok(path)) }
+            if path.extension() != Some(OsStr::new("nds")) {
+                None
+            } else {
+                Some(Ok(path))
+            }
         });
         Ok(iter)
     }

--- a/lib/tests/common.rs
+++ b/lib/tests/common.rs
@@ -1,0 +1,36 @@
+use std::{ffi::OsStr, path::PathBuf};
+
+use anyhow::{Result, anyhow};
+use ds_rom::crypto::blowfish::BlowfishKey;
+
+#[allow(unused)]
+pub struct RomsTest {
+    pub roms_dir: PathBuf,
+    pub key: BlowfishKey,
+}
+
+impl RomsTest {
+    pub fn new() -> Result<Self> {
+        let cwd = std::env::current_dir()?;
+        let roms_dir = cwd.join("tests/roms/");
+        let arm7_bios = roms_dir.join("arm7_bios.bin");
+        assert!(arm7_bios.exists());
+        assert!(arm7_bios.is_file());
+
+        let key = BlowfishKey::from_arm7_bios_path(arm7_bios)?;
+
+        Ok(Self { roms_dir, key })
+    }
+
+    pub fn roms(&self) -> Result<impl Iterator<Item = Result<PathBuf>>> {
+        let iter = self.roms_dir.read_dir()?.filter_map(|entry| {
+            let entry = match entry {
+                Ok(entry) => entry,
+                Err(e) => return Some(Err(anyhow!(e))),
+            };
+            let path = entry.path();
+            if path.extension() != Some(OsStr::new("nds")) { None } else { Some(Ok(path)) }
+        });
+        Ok(iter)
+    }
+}

--- a/lib/tests/test_dsprot.rs
+++ b/lib/tests/test_dsprot.rs
@@ -1,0 +1,67 @@
+use anyhow::Result;
+use ds_rom::{
+    crypto::dsprot::DecryptOptions,
+    rom::{Rom, raw},
+};
+use log::LevelFilter;
+
+use crate::common::RomsTest;
+
+mod common;
+
+#[test]
+fn test_dsprot_decrypt_encrypt() -> Result<()> {
+    env_logger::builder().filter_level(LevelFilter::Info).init();
+
+    let test = RomsTest::new()?;
+    for path in test.roms()? {
+        let path = path?;
+        log::info!("Decrypting and re-encrypting {}", path.display());
+
+        // Extract
+        let raw_rom = raw::Rom::from_file(&path)?;
+        let rom = Rom::extract(&raw_rom)?;
+
+        // There's no counterpart to `decode_literals` for re-encryption, so it must be false
+        let decrypt_options = DecryptOptions { decode_literals: false };
+
+        // Decrypt and re-encrypt
+        let arm9 = rom.arm9();
+        if arm9.dsprot_state().is_encrypted() {
+            let mut arm9_clone = arm9.clone();
+            let compressed = arm9_clone.is_compressed()?;
+            if compressed {
+                arm9_clone.decompress()?;
+            }
+            arm9_clone.decrypt_dsprot(&decrypt_options)?;
+            arm9_clone.encrypt_dsprot()?;
+            if compressed {
+                arm9_clone.compress()?;
+            }
+            assert!(arm9 == &arm9_clone, "DS Protect re-encryption failed in ARM9 program of {}", path.display());
+            log::info!("DS Protect re-encrypted in ARM9 program");
+        }
+        for overlay in rom.arm9_overlays() {
+            if overlay.dsprot_state().is_encrypted() {
+                let mut overlay_clone = overlay.clone();
+                let compressed = overlay.is_compressed();
+                if compressed {
+                    overlay_clone.decompress()?;
+                }
+                overlay_clone.decrypt_dsprot(&decrypt_options)?;
+                overlay_clone.encrypt_dsprot()?;
+                if compressed {
+                    overlay_clone.compress()?;
+                }
+                assert!(
+                    overlay == &overlay_clone,
+                    "DS Protect re-encryption failed in ARM9 overlay {} of {}",
+                    overlay.id(),
+                    path.display(),
+                );
+                log::info!("DS Protect re-encrypted in ARM9 overlay {}", overlay.id());
+            }
+        }
+    }
+    Ok(())
+}

--- a/lib/tests/test_dsprot.rs
+++ b/lib/tests/test_dsprot.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 use ds_rom::{
-    crypto::dsprot::DecryptOptions,
+    crypto::dsprot::{DsProtDecryptOptions, DsProtEncryptOptions},
     rom::{Rom, raw},
 };
 use log::LevelFilter;
@@ -22,8 +22,8 @@ fn test_dsprot_decrypt_encrypt() -> Result<()> {
         let raw_rom = raw::Rom::from_file(&path)?;
         let rom = Rom::extract(&raw_rom)?;
 
-        // There's no counterpart to `decode_literals` for re-encryption, so it must be false
-        let decrypt_options = DecryptOptions { decode_literals: false };
+        let decrypt_options = DsProtDecryptOptions { decode_relocations: true };
+        let encrypt_options = DsProtEncryptOptions { encode_relocations: true };
 
         // Decrypt and re-encrypt
         let arm9 = rom.arm9();
@@ -34,7 +34,7 @@ fn test_dsprot_decrypt_encrypt() -> Result<()> {
                 arm9_clone.decompress()?;
             }
             arm9_clone.decrypt_dsprot(&decrypt_options)?;
-            arm9_clone.encrypt_dsprot()?;
+            arm9_clone.encrypt_dsprot(&encrypt_options)?;
             if compressed {
                 arm9_clone.compress()?;
             }
@@ -49,7 +49,7 @@ fn test_dsprot_decrypt_encrypt() -> Result<()> {
                     overlay_clone.decompress()?;
                 }
                 overlay_clone.decrypt_dsprot(&decrypt_options)?;
-                overlay_clone.encrypt_dsprot()?;
+                overlay_clone.encrypt_dsprot(&encrypt_options)?;
                 if compressed {
                     overlay_clone.compress()?;
                 }

--- a/lib/tests/test_extract_build.rs
+++ b/lib/tests/test_extract_build.rs
@@ -1,30 +1,19 @@
-use std::{ffi::OsStr, fs};
+use std::fs;
 
 use anyhow::Result;
-use ds_rom::{
-    crypto::blowfish::BlowfishKey,
-    rom::{raw, Rom},
-};
+use ds_rom::rom::{Rom, raw};
 use log::LevelFilter;
+
+use crate::common::RomsTest;
+mod common;
 
 #[test]
 fn test_extract_build() -> Result<()> {
     env_logger::builder().filter_level(LevelFilter::Info).init();
 
-    let cwd = std::env::current_dir()?;
-    let roms_dir = cwd.join("tests/roms/");
-    let arm7_bios = roms_dir.join("arm7_bios.bin");
-    assert!(arm7_bios.exists());
-    assert!(arm7_bios.is_file());
-
-    let key = BlowfishKey::from_arm7_bios_path(arm7_bios)?;
-
-    for entry in roms_dir.read_dir()? {
-        let entry = entry?;
-        let path = entry.path();
-        if path.extension() != Some(OsStr::new("nds")) {
-            continue;
-        }
+    let test = RomsTest::new()?;
+    for path in test.roms()? {
+        let path = path?;
         let file_name = path.file_name().unwrap().to_string_lossy();
         if file_name.starts_with("build_") {
             continue;
@@ -33,18 +22,18 @@ fn test_extract_build() -> Result<()> {
         // Extract
         let extension = path.extension().unwrap().to_string_lossy();
         let base_name = file_name.strip_suffix(extension.as_ref()).unwrap().strip_suffix(".").unwrap();
-        let extract_path = roms_dir.join(base_name);
+        let extract_path = test.roms_dir.join(base_name);
 
         let raw_rom = raw::Rom::from_file(&path)?;
         let rom = Rom::extract(&raw_rom)?;
-        rom.save(&extract_path, Some(&key))?;
+        rom.save(&extract_path, Some(&test.key))?;
 
         // Build
         let build_path = path.with_file_name(format!("build_{file_name}"));
         let config_path = extract_path.join("config.yaml");
 
         let rom = Rom::load(&config_path, Default::default())?;
-        let raw_rom = rom.build(Some(&key))?;
+        let raw_rom = rom.build(Some(&test.key))?;
         raw_rom.save(&build_path)?;
 
         // Compare

--- a/lib/tests/test_extract_build.rs
+++ b/lib/tests/test_extract_build.rs
@@ -1,7 +1,7 @@
 use std::fs;
 
 use anyhow::Result;
-use ds_rom::rom::{Rom, raw};
+use ds_rom::rom::{Rom, RomLoadOptions, raw};
 use log::LevelFilter;
 
 use crate::common::RomsTest;
@@ -32,7 +32,7 @@ fn test_extract_build() -> Result<()> {
         let build_path = path.with_file_name(format!("build_{file_name}"));
         let config_path = extract_path.join("config.yaml");
 
-        let rom = Rom::load(&config_path, Default::default())?;
+        let rom = Rom::load(&config_path, RomLoadOptions { key: Some(&test.key), ..Default::default() })?;
         let raw_rom = rom.build(Some(&test.key))?;
         raw_rom.save(&build_path)?;
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -5,3 +5,4 @@ overflow_delimited_expr = true
 reorder_impl_items = true
 use_field_init_shorthand = true
 use_small_heuristics = "Max"
+single_line_if_else_max_width = 70


### PR DESCRIPTION
This update mainly focuses on decrypting functions from DS Protect, an emulator/flashcart detector library that exists in over 300 DS titles. There are also a few game compatibility improvements.

CLI changes:
- When extracted to files on disk, DS Protect functions will be decrypted in whichever module they live in (ARM9 program or ARM9 overlay).
- When building a ROM from extracted files, the DS Protect functions will be re-encrypted to match the original ROM.

API changes:
- Deprecated: `Arm9::with_two_tcms` in favor of `Arm9::with_autoloads`
- Added: `Arm9::decrypt_dsprot` and `Overlay::decrypt_dsprot`
- Added: `Arm9::encrypt_dsprot` and `Overlay::encrypt_dsprot`
- Added: `Arm9::dsprot_state` and `Overlay::dsprot_state`
- Added: `Overlay::originally_signed`
- Removed: `raw::Rom::section_padding_value`
- Privated: `raw::Rom::file_image_padding_value`
- Added: `raw::Rom::padding_values` (in place of the two above)
- Removed: `Rom::arm9_build_config` (was only meant to be used internally)

Game compatibility improvements:
- Detect unencrypted secure areas that don't start with `SECURE_AREA_ID`, and do not attempt to decrypt those
- More granular section padding values. Fixes #27.
- Accept multiboot signatures on any byte alignment. Fixes #26.